### PR TITLE
feat: Progress Report I — full demo scope implementation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\Emir\\\\Desktop\\\\ACADEMY\\\\ens491\\\\ens491-rl-project\" -Recurse -Force)",
+      "Bash(Select-Object FullName)",
+      "Bash(Sort-Object FullName)",
+      "PowerShell(Get-ChildItem -Path \"C:\\\\Users\\\\Emir\\\\Desktop\\\\ACADEMY\\\\ens491\\\\ens491-rl-project\" -Recurse -Force | ForEach-Object { $_.FullName })"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,15 @@
       "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\Emir\\\\Desktop\\\\ACADEMY\\\\ens491\\\\ens491-rl-project\" -Recurse -Force)",
       "Bash(Select-Object FullName)",
       "Bash(Sort-Object FullName)",
-      "PowerShell(Get-ChildItem -Path \"C:\\\\Users\\\\Emir\\\\Desktop\\\\ACADEMY\\\\ens491\\\\ens491-rl-project\" -Recurse -Force | ForEach-Object { $_.FullName })"
+      "PowerShell(Get-ChildItem -Path \"C:\\\\Users\\\\Emir\\\\Desktop\\\\ACADEMY\\\\ens491\\\\ens491-rl-project\" -Recurse -Force | ForEach-Object { $_.FullName })",
+      "Bash(python -m pytest tests/ -v)",
+      "Bash(\"C:\\\\Users\\\\Emir\\\\miniconda3\\\\envs\\\\ens491\\\\python.exe\" -m pytest tests/ -v)",
+      "Bash(C:\\\\Users\\\\Emir\\\\miniconda3\\\\envs\\\\ens491\\\\python.exe *)",
+      "Bash(\"C:\\\\Users\\\\Emir\\\\miniconda3\\\\envs\\\\ens491\\\\python.exe\" -m pip list)",
+      "Bash(findstr /i \"tensor\")",
+      "Bash(\"C:\\\\Users\\\\Emir\\\\miniconda3\\\\envs\\\\ens491\\\\python.exe\" -m pytest tests/ -v --tb=short)",
+      "Bash(New-Item -ItemType Directory -Path \"C:\\\\Users\\\\Emir\\\\Desktop\\\\ACADEMY\\\\ens491\\\\ens491-rl-project\\\\runs\" -Force)",
+      "Bash(New-Item -ItemType File -Path \"C:\\\\Users\\\\Emir\\\\Desktop\\\\ACADEMY\\\\ens491\\\\ens491-rl-project\\\\runs\\\\.gitkeep\" -Force)"
     ]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,6 @@ Before writing any code, read the relevant doc:
 
 - `docs/ENS491_Module_Interfaces.md` — input/output contracts for every module. **Do not deviate from these interfaces.**
 - `docs/ENS491_Recursive_Hierarchy_Design.md` — formal hierarchy design, {n,m} notation, recursive structure.
-- `docs/ENS491_Project_State.md` — roadmap, story points, current status.
 
 ---
 
@@ -73,19 +72,17 @@ Before writing any code, read the relevant doc:
 
 ---
 
-## Current Status
+## What To Build
 
-**Done:**
-- PPO baseline on Empty-8x8 (`sandbox/minigrid-basics/train_ppo.py`)
-- Catastrophic forgetting demonstrated
-- Doric PN test (`sandbox/progressive-networks/doric_test.py`)
+Four modules, all empty right now. Fill them in this order:
 
-**Next (critical path):**
-1. `src/continual_learning/` — custom PN, 2 columns, lateral connections, PPO training
-2. `src/task_detection/` — AE (MLP, 147→64→32→64→147) + GRU (hidden=64, N=20)
-3. `src/options/` — Option wrapper + PPO MetaController (Discrete action space)
-4. Integration script
-5. `src/gui/` — Streamlit: reconstruction error, active column, option history
+1. `src/continual_learning/` — Progressive Networks (2 columns, lateral connections, PPO training)
+2. `src/task_detection/` — Autoencoder (MLP, 147→64→32→64→147) + GRU task identifier (hidden=64, N=20, supervised)
+3. `src/options/` — Option wrapper + MetaController (SB3 PPO, Discrete action space)
+4. Integration script — AE → GRU → MetaController → Option → env pipeline
+5. `src/gui/` — Streamlit: reconstruction error curve, active column, option selection history
+
+Each module's exact interface is in `docs/ENS491_Module_Interfaces.md`. Build to that spec.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ docs/                   # Architecture and design documents (read these first)
 sandbox/                # Reference only — do not modify
 ```
 
-All four `src/` modules are currently empty. Build them in the order listed above.
+All four `src/` modules are implemented (Phase 1). The MetaController uses epsilon-greedy selection in Phase 1 — PPO-based MC is deferred to Phase 2 due to dynamic action space complexity.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,38 @@
 # CLAUDE.md
 
-This file is the briefing for Claude Code. Read this before touching any file.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ---
 
 ## What This Project Is
 
-A hierarchical continual reinforcement learning agent that:
-- Learns multiple tasks sequentially **without catastrophic forgetting**
-- Reuses learned skills as macro-actions (options) in higher-level policies
-- Detects novel tasks autonomously via reconstruction error
-- Grows its hierarchy unboundedly at runtime
+A hierarchical continual reinforcement learning agent that learns multiple tasks sequentially without catastrophic forgetting, reuses learned skills as macro-actions (options) in higher-level policies, and detects novel tasks autonomously via reconstruction error. The hierarchy grows unboundedly at runtime.
 
 Evaluation environment: **MiniGrid** (Empty-8x8 → FourRooms → DoorKey → KeyCorridor).
 
 ---
 
-## Repo Structure
+## Commands
 
+All commands assume the `ens491` conda environment is active:
+
+```bash
+conda activate ens491
 ```
-src/
-  continual_learning/   # Progressive Networks columns (PN)
-  task_detection/       # Autoencoder (AE) + GRU task identifier
-  options/              # Option wrapper + MetaController
-  gui/                  # Streamlit visualization
-tests/
-docs/                   # Architecture and design documents (read these)
+
+Run all tests:
+```bash
+pytest tests/ -v
+```
+
+Run a single test file:
+```bash
+pytest tests/test_placeholder.py -v
+```
+
+Run the Streamlit GUI:
+```bash
+streamlit run src/gui/app.py
 ```
 
 ---
@@ -36,28 +43,145 @@ Before writing any code, read the relevant doc:
 
 - `docs/ENS491_Module_Interfaces.md` — input/output contracts for every module. **Do not deviate from these interfaces.**
 - `docs/ENS491_Recursive_Hierarchy_Design.md` — formal hierarchy design, {n,m} notation, recursive structure.
+- `docs/ENS491_Project_State.md` — locked decisions, open empirical questions, roadmap, and current status.
 
 ---
 
 ## Stack
 
-- Python 3.10, PyTorch + CUDA
+- Python 3.10, PyTorch + CUDA (RTX 3070 Ti, CUDA 12.1)
 - MiniGrid (`pip install minigrid`), Stable-Baselines3, Gymnasium
 - Experiment tracking: Weights & Biases
 - GUI: Streamlit
+- Do not install packages outside the `ens491` conda environment
+
+---
+
+## Repo Structure
+
+```
+src/
+  continual_learning/   # Progressive Networks columns (PN) — build first
+  task_detection/       # Autoencoder (AE) + GRU task identifier — build second
+  options/              # Option wrapper + MetaController — build third
+  gui/                  # Streamlit visualization — build last
+tests/
+docs/                   # Architecture and design documents (read these first)
+sandbox/                # Reference only — do not modify
+```
+
+All four `src/` modules are currently empty. Build them in the order listed above.
+
+---
+
+## Architecture: Signal Flow
+
+Every environment step runs this pipeline:
+
+```
+obs_t → [AE] → is_novel?
+                  ├─ True  → on_novel_task_detected() → open new Column → train → stabilize → add_option()
+                  └─ False → [GRU] → task_id → [TaskLifecycleManager]
+                                                       └─ recursive_step(obs, root_MetaController)
+                                                              └─ MC.select_option() → Option.step()
+                                                                     ├─ sub_layer=None (LEAF): Column.forward() → action → env
+                                                                     └─ sub_layer=MC (NON-LEAF): recurse deeper
+```
+
+Key architectural property: `TaskLifecycleManager` only calls the root `MetaController`. It does not know or care how many levels exist below. Adding a new layer only requires setting a `Column.sub_layer = MetaController(...)` — nothing at the root changes.
+
+---
+
+## Critical Path
+
+The following sequence is blocking — if any step is skipped, the full system cannot be assembled:
+
+```
+PN-1 → PN-2 → PN-3* → PN-4 → OPT-1 → OPT-2 → INT-2
+                ↑
+        Recursive hierarchy design must be finalized on paper before PN-3
+```
+
+Can be started in parallel (does not block critical path): `AE-1, AE-2, GRU-1, GRU-2, EVAL-1, EVAL-2`
+
+---
+
+## Module Interfaces (Quick Reference)
+
+```python
+# AE
+AEOutput(reconstruction_error: float, is_novel: bool, latent_z: Tensor)
+
+# GRU
+GRUOutput(task_id: int, confidence: float, all_probs: Tensor)  # task_id=-1 means uncertain
+
+# Column
+Column(n, m, frozen, lateral_source, sub_layer)
+column.forward(obs) -> ColumnOutput(action, value, activations)
+
+# Option
+option.step(obs) -> OptionStepOutput(action: int, terminated: bool, info: dict)
+
+# MetaController
+mc.select_option(obs) -> MetaControllerOutput(selected_option_id, option)
+mc.add_option(option) -> None  # does NOT retrain from scratch; uses exploration bonus
+
+# TaskLifecycleManager
+tlm.step(obs) -> Action  # the single entry point for every env step
+```
+
+Full interface spec: `docs/ENS491_Module_Interfaces.md`
+
+---
+
+## Network Architectures
+
+**Column policy network:** MLP `147 → 64 → 64 → 7` (input obs → hidden → hidden → actions). Use for all columns unless explicitly told otherwise.
+
+**Autoencoder:** MLP `147 → 64 → 32 → 64 → 147`. Input is always `(147,)` because `FlatObsWrapper` is always applied. The convolutional AE mentioned in `ENS491_Project_State.md` is outdated — ignore it.
+
+**GRU task identifier:** hidden size 64, sequence length N=20, supervised training.
+
+---
+
+## SB3 Integration Pattern
+
+Subclass SB3's `ActorCriticPolicy` and override the forward pass to inject lateral connections. Keep SB3's training loop intact — do not reimplement PPO.
+
+**If any of the following occur, stop and report before attempting a workaround:**
+- Lateral activations are not accessible inside the custom policy's forward pass
+- Gradient flow through lateral connections is broken
+- VecEnv is incompatible with the lateral activation sharing mechanism
+
+---
+
+## Lateral Connection Mechanism
+
+Column `{n, m}` reads the 64-dim hidden activations from `{n, m-1}`, passes them through `nn.Linear(64, 64)`, and **adds** the result element-wise to its own 64-dim hidden. No concatenation.
+
+---
+
+## Stabilization Criterion
+
+A column is stabilized when, over the **last 50 episodes**:
+- Mean episode reward > 0.85
+- Standard deviation of episode reward < 0.05
+
+Only after both conditions are met is the column frozen and wrapped as an option. This is the only stabilization criterion — do not invent others.
 
 ---
 
 ## Hard Rules — Never Break These
 
 **Environment:**
-- Always use `FlatObsWrapper` + `MlpPolicy`. **Never use CnnPolicy** — MiniGrid obs is 7×7, smaller than default 8×8 CNN kernel.
+- Always use `FlatObsWrapper` + `MlpPolicy`. **Never use CnnPolicy** — MiniGrid obs is 7×7, smaller than the default 8×8 CNN kernel.
 - Observation shape after FlatObsWrapper: `(147,)` float32.
 
 **Progressive Networks:**
 - `frozen=True` means **no gradient**, but **forward pass still runs**. Lateral connections need activations from frozen columns.
 - Never modify a frozen column's weights for any reason.
 - `sub_layer` field must exist on `Column` even if `None` in Phase 1. Do not remove it.
+- Lateral connections are defined only within a layer, left to right: `{n, m-1} → {n, m}`.
 
 **Signals:**
 - `reconstruction_error` (AE) and `sub_policy_reward` are **separate signals**. Never merge into a single threshold.
@@ -69,45 +193,7 @@ Before writing any code, read the relevant doc:
 **Hierarchy:**
 - The system is unbounded by design. Never hardcode number of layers or columns.
 - New layer = set `column.sub_layer = MetaController(...)`. Nothing else changes at root level.
-
----
-
-## What To Build
-
-Four modules, all empty right now. Fill them in this order:
-
-1. `src/continual_learning/` — Progressive Networks (2 columns, lateral connections, PPO training)
-2. `src/task_detection/` — Autoencoder (MLP, 147→64→32→64→147) + GRU task identifier (hidden=64, N=20, supervised)
-3. `src/options/` — Option wrapper + MetaController (SB3 PPO, Discrete action space)
-4. Integration script — AE → GRU → MetaController → Option → env pipeline
-5. `src/gui/` — Streamlit: reconstruction error curve, active column, option selection history
-
-Each module's exact interface is in `docs/ENS491_Module_Interfaces.md`. Build to that spec.
-
----
-
-## Module Interfaces (Quick Reference)
-
-```python
-# AE output
-AEOutput(reconstruction_error: float, is_novel: bool, latent_z: Tensor)
-
-# GRU output  
-GRUOutput(task_id: int, confidence: float, all_probs: Tensor)
-
-# Column
-Column(n, m, frozen, lateral_source, sub_layer)
-column.forward(obs) -> ColumnOutput(action, value, activations)
-
-# Option
-option.step(obs) -> OptionStepOutput(action: int, terminated: bool, info: dict)
-
-# MetaController
-mc.select_option(obs) -> MetaControllerOutput(selected_option_id, option)
-mc.add_option(option) -> None
-```
-
-Full interface spec: `docs/ENS491_Module_Interfaces.md`
+- Hierarchy is a **tree** (not DAG) in Phase 1-2 — each column belongs to exactly one MetaController.
 
 ---
 
@@ -119,5 +205,5 @@ Full interface spec: `docs/ENS491_Module_Interfaces.md`
 - Do not add unstabilized options to MetaController
 - Do not remove `sub_layer` field from Column
 - Do not use `localStorage` or any browser storage in GUI artifacts
-- Do not install packages outside the `ens491` conda environment
-- Do not modify `sandbox/` — it is reference only
+- Do not reference or use the sandbox repo — build any needed baselines from scratch here
+- Do not change module interfaces without updating `docs/ENS491_Module_Interfaces.md` first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,126 @@
+# CLAUDE.md
+
+This file is the briefing for Claude Code. Read this before touching any file.
+
+---
+
+## What This Project Is
+
+A hierarchical continual reinforcement learning agent that:
+- Learns multiple tasks sequentially **without catastrophic forgetting**
+- Reuses learned skills as macro-actions (options) in higher-level policies
+- Detects novel tasks autonomously via reconstruction error
+- Grows its hierarchy unboundedly at runtime
+
+Evaluation environment: **MiniGrid** (Empty-8x8 → FourRooms → DoorKey → KeyCorridor).
+
+---
+
+## Repo Structure
+
+```
+src/
+  continual_learning/   # Progressive Networks columns (PN)
+  task_detection/       # Autoencoder (AE) + GRU task identifier
+  options/              # Option wrapper + MetaController
+  gui/                  # Streamlit visualization
+tests/
+docs/                   # Architecture and design documents (read these)
+```
+
+---
+
+## Read These Docs First
+
+Before writing any code, read the relevant doc:
+
+- `docs/ENS491_Module_Interfaces.md` — input/output contracts for every module. **Do not deviate from these interfaces.**
+- `docs/ENS491_Recursive_Hierarchy_Design.md` — formal hierarchy design, {n,m} notation, recursive structure.
+- `docs/ENS491_Project_State.md` — roadmap, story points, current status.
+
+---
+
+## Stack
+
+- Python 3.10, PyTorch + CUDA
+- MiniGrid (`pip install minigrid`), Stable-Baselines3, Gymnasium
+- Experiment tracking: Weights & Biases
+- GUI: Streamlit
+
+---
+
+## Hard Rules — Never Break These
+
+**Environment:**
+- Always use `FlatObsWrapper` + `MlpPolicy`. **Never use CnnPolicy** — MiniGrid obs is 7×7, smaller than default 8×8 CNN kernel.
+- Observation shape after FlatObsWrapper: `(147,)` float32.
+
+**Progressive Networks:**
+- `frozen=True` means **no gradient**, but **forward pass still runs**. Lateral connections need activations from frozen columns.
+- Never modify a frozen column's weights for any reason.
+- `sub_layer` field must exist on `Column` even if `None` in Phase 1. Do not remove it.
+
+**Signals:**
+- `reconstruction_error` (AE) and `sub_policy_reward` are **separate signals**. Never merge into a single threshold.
+- Meta-controller reward and sub-policy reward travel on **separate channels**.
+
+**Options:**
+- Never add an option to MetaController before its column is stabilized (training complete, reward plateau reached).
+
+**Hierarchy:**
+- The system is unbounded by design. Never hardcode number of layers or columns.
+- New layer = set `column.sub_layer = MetaController(...)`. Nothing else changes at root level.
+
+---
+
+## Current Status
+
+**Done:**
+- PPO baseline on Empty-8x8 (`sandbox/minigrid-basics/train_ppo.py`)
+- Catastrophic forgetting demonstrated
+- Doric PN test (`sandbox/progressive-networks/doric_test.py`)
+
+**Next (critical path):**
+1. `src/continual_learning/` — custom PN, 2 columns, lateral connections, PPO training
+2. `src/task_detection/` — AE (MLP, 147→64→32→64→147) + GRU (hidden=64, N=20)
+3. `src/options/` — Option wrapper + PPO MetaController (Discrete action space)
+4. Integration script
+5. `src/gui/` — Streamlit: reconstruction error, active column, option history
+
+---
+
+## Module Interfaces (Quick Reference)
+
+```python
+# AE output
+AEOutput(reconstruction_error: float, is_novel: bool, latent_z: Tensor)
+
+# GRU output  
+GRUOutput(task_id: int, confidence: float, all_probs: Tensor)
+
+# Column
+Column(n, m, frozen, lateral_source, sub_layer)
+column.forward(obs) -> ColumnOutput(action, value, activations)
+
+# Option
+option.step(obs) -> OptionStepOutput(action: int, terminated: bool, info: dict)
+
+# MetaController
+mc.select_option(obs) -> MetaControllerOutput(selected_option_id, option)
+mc.add_option(option) -> None
+```
+
+Full interface spec: `docs/ENS491_Module_Interfaces.md`
+
+---
+
+## What NOT To Do
+
+- Do not use CnnPolicy anywhere
+- Do not hardcode layer/column counts
+- Do not merge AE and reward signals
+- Do not add unstabilized options to MetaController
+- Do not remove `sub_layer` field from Column
+- Do not use `localStorage` or any browser storage in GUI artifacts
+- Do not install packages outside the `ens491` conda environment
+- Do not modify `sandbox/` — it is reference only

--- a/docs/ENS491_Module_Interfaces.md
+++ b/docs/ENS491_Module_Interfaces.md
@@ -1,234 +1,234 @@
-# ENS 491 — Modül Interface Spesifikasyonu
+# ENS 491 — Module Interface Specification
 
-> Her modülün input/output kontratı. Paralel geliştirmede bu doküman referans.  
-> Bir modülün içi değişebilir — ama bu kontrattan sapılmaz.  
-> Değişiklik gerekirse önce burası güncellenir, sonra kod.
+> Input/output contracts for every module. This is the reference during parallel development.  
+> Module internals can change — but these contracts do not.  
+> If a contract needs to change, update this document first, then the code.
 
 ---
 
-## Genel Tipler
+## Common Types
 
 ```python
 import torch
-import numpy as np
 from dataclasses import dataclass
 from typing import Optional
 
-# MiniGrid observation: 7×7×3 uint8 array (FlatObsWrapper sonrası 147-dim float vector)
+# MiniGrid observation: 7×7×3 uint8 (after FlatObsWrapper: 147-dim float vector)
 Observation = torch.Tensor       # shape: (147,) — flattened
-ObsSequence  = torch.Tensor       # shape: (N, 147) — son N gözlem
+ObsSequence  = torch.Tensor       # shape: (N, 147) — last N observations
 Action       = int                # discrete: 0-6 (MiniGrid action space)
-TaskID       = int                # 0-indexed, -1 = bilinmiyor
-LayerIdx     = int                # n — hiyerarşi katmanı
-ColumnIdx    = int                # m — katman içi sütun sırası
+TaskID       = int                # 0-indexed, -1 = unknown
+LayerIdx     = int                # n — hierarchy layer
+ColumnIdx    = int                # m — column position within layer
 ```
 
 ---
 
-## Modül 1: Autoencoder (AE)
+## Module 1: Autoencoder (AE)
 
-**Sorumluluğu:** "Bu gözlemi daha önce gördüm mü?"
+**Responsibility:** "Have I seen this observation before?"
 
 ```python
 @dataclass
 class AEOutput:
-    reconstruction_error: float       # MSE — düşük = tanıdık, yüksek = yabancı
-    is_novel: bool                    # error > threshold ise True
-    latent_z: torch.Tensor            # shape: (latent_dim,) — downstream kullanım için
+    reconstruction_error: float       # MSE — low = familiar, high = novel
+    is_novel: bool                    # True if error > threshold
+    latent_z: torch.Tensor            # shape: (latent_dim,) — for downstream use
 
 class AutoencoderModule:
     def encode(self, obs: Observation) -> torch.Tensor:
-        """Gözlemi latent space'e sıkıştır."""
+        """Compress observation into latent space."""
         ...
 
     def decode(self, z: torch.Tensor) -> Observation:
-        """Latent vektörden gözlemi yeniden oluştur."""
+        """Reconstruct observation from latent vector."""
         ...
 
     def forward(self, obs: Observation) -> AEOutput:
-        """Ana interface. Her adımda çağrılan metot."""
+        """Main interface. Called every step."""
         ...
 
     def update_threshold(self, recent_errors: list[float]) -> None:
-        """Threshold güncelleme — adaptive stratejiler için."""
+        """Update detection threshold."""
         ...
 ```
 
-**Notlar:**
-- `is_novel = True` → GRU'ya geçme, yeni sütun sürecini başlat
-- `is_novel = False` → GRU devreye girer
-- `latent_z` şimdilik kullanılmayabilir ama downstream (GRU input, task representation) için hazır tutulur
-- Threshold stratejisi (sabit / adaptive / istatistiksel) AE içinde kapsüllenir — dışarıdan sadece `is_novel` görünür
+**Notes:**
+- `is_novel = True` → skip GRU, trigger new column process
+- `is_novel = False` → pass to GRU
+- `latent_z` may be unused initially but kept for downstream use (GRU input, task representation)
+- Threshold strategy (fixed / adaptive / statistical) is encapsulated inside AE — callers only see `is_novel`
 
 ---
 
-## Modül 2: GRU Task Identifier
+## Module 2: GRU Task Identifier
 
-**Sorumluluğu:** "Bu hangi görev?"
+**Responsibility:** "Which task is this?"
 
 ```python
 @dataclass
 class GRUOutput:
-    task_id: TaskID                   # tahmin edilen görev ID'si (-1 = belirsiz)
+    task_id: TaskID                   # predicted task ID (-1 = uncertain)
     confidence: float                 # [0.0, 1.0]
-    all_probs: torch.Tensor           # shape: (num_known_tasks,) — softmax çıktısı
+    all_probs: torch.Tensor           # shape: (num_known_tasks,) — softmax output
 
 class GRUTaskIdentifier:
     def forward(self, obs_sequence: ObsSequence) -> GRUOutput:
-        """Son N gözlemi al, görev tahmin et."""
+        """Take last N observations, predict task."""
         ...
 
     def register_new_task(self, task_id: TaskID) -> None:
-        """Yeni görev öğrenilince çıktı boyutunu güncelle."""
+        """Expand output dimension when a new task is learned."""
         ...
 ```
 
-**Notlar:**
-- `obs_sequence` son N adımın gözlemleri — N hyperparameter (5 / 20 / 50 empirik karşılaştırılacak)
-- `task_id = -1` → GRU emin değil, sistemin davranışı TBD (⚠️ supervisor onayı)
-- AE `is_novel = False` dediğinde GRU çağrılır — AE `is_novel = True` dediğinde GRU çağrılmaz
-- Phase 1'de supervised (label'lı), sonraki aşamada label-free geçiş denenecek
+**Notes:**
+- `obs_sequence` is the last N steps — N=20
+- `task_id = -1` → GRU uncertain, system behavior TBD
+- GRU is called only when AE returns `is_novel = False`
+- Trained with supervised labels in Phase 1
 
 ---
 
-## Modül 3: Progressive Networks Column
+## Module 3: Progressive Networks Column
 
-**Sorumluluğu:** "Bu görevi nasıl yaparım?" + lateral transfer sağla
+**Responsibility:** "How do I solve this task?" + provide lateral transfer
 
 ```python
 @dataclass
 class ColumnOutput:
-    action: Action                              # seçilen eylem
+    action: Action                              # selected action
     value: float                                # PPO value estimate
-    activations: dict[int, torch.Tensor]        # katman_idx → aktivasyon (lateral için)
+    activations: dict[int, torch.Tensor]        # layer_idx → activation (for lateral)
 
 class Column:
     n: LayerIdx
     m: ColumnIdx
     frozen: bool
-    lateral_source: Optional['Column']          # {n, m-1} referansı, None ise ilk sütun
-    sub_layer: Optional['MetaController']       # None ise leaf (primitive), varsa recursive
+    lateral_source: Optional['Column']          # ref to {n, m-1}, None if first column
+    sub_layer: Optional['MetaController']       # None = leaf (primitive), else recursive
 
     def forward(self, obs: Observation) -> ColumnOutput:
         """
-        İki farklı davranış — sub_layer'a göre ayrışır:
+        Two behaviors depending on sub_layer:
 
         Leaf (sub_layer=None):
-            - Gözlemi işle, doğrudan action üret.
-            - lateral_source varsa aktivasyonlarını çek ve entegre et.
-            - frozen=True ise gradient hesaplanmaz.
+            - Process observation, produce action directly.
+            - If lateral_source exists, pull its activations and integrate.
+            - If frozen=True, no gradient computed.
 
         Non-leaf (sub_layer=MetaController):
-            - Bu Column kendi action'ını üretmez.
-            - sub_layer.select_option(obs) çağrılır.
-            - Seçilen option kendi forward()'ını çalıştırır (recursive).
-            - En alttaki leaf'ten gelen action yukarı taşınır.
-            - Bu Column'un policy ağırlıkları meta-controller eğitimi için kullanılır,
-              doğrudan env action için değil.
+            - This Column does NOT produce an action directly.
+            - Calls sub_layer.select_option(obs).
+            - Selected option runs its own forward() (recursive).
+            - Action from the deepest leaf propagates upward.
+            - This Column's policy weights are used for meta-controller training,
+              not for direct env actions.
         """
         ...
 
     def freeze(self) -> None:
-        """Ağırlıkları dondur. Eğitim tamamlanınca çağrılır."""
+        """Freeze weights. Called when training is complete."""
         ...
 
     def get_activations(self) -> dict[int, torch.Tensor]:
-        """Son forward pass'in ara katman aktivasyonları. Lateral için."""
+        """Return intermediate activations from last forward pass. Used by lateral connections."""
         ...
 
     def as_option(self) -> 'Option':
-        """Bu sütunu Option olarak wrap et."""
+        """Wrap this column as an Option."""
         ...
 ```
 
-**Notlar:**
-- `frozen=True` → gradient yok, ama forward pass çalışır (lateral bağlantılar için gerekli) 🔒
-- `activations` dict'i `get_activations()` ile bir sonraki sütun tarafından okunur
+**Notes:**
+- `frozen=True` → no gradient, but forward pass still runs (required for lateral connections) 🔒
+- `activations` dict is read via `get_activations()` by the next column
 - `sub_layer=None` → leaf node (n=0, primitive skill)
-- `sub_layer=MetaController(...)` → bu sütun hem policy hem bir alt hiyerarşiyi yönetiyor
+- `sub_layer=MetaController(...)` → this column is both a policy and a hierarchy manager
+- `sub_layer` field must exist even if `None` in Phase 1 — do not remove it
 
 ---
 
-## Modül 4: Option Wrapper
+## Module 4: Option Wrapper
 
-**Sorumluluğu:** Sütunu Sutton et al. (1999) option formatına çevir
+**Responsibility:** Wrap a Column into the Sutton et al. (1999) option format
 
 ```python
 @dataclass
 class OptionStepOutput:
     action: Action
-    terminated: bool        # bu adımda option bitti mi?
-    info: dict              # debug bilgisi — adım sayısı, internal reward vs.
+    terminated: bool        # did this option terminate on this step?
+    info: dict              # debug — step count, internal reward, etc.
 
 class Option:
     column: Column
     option_id: int
-    step_count: int         # kaç adımdır çalışıyor
+    step_count: int         # steps elapsed since this option was invoked
 
     def step(self, obs: Observation) -> OptionStepOutput:
-        """Bir adım çalıştır, termination kontrol et."""
+        """Run one step, check termination."""
         ...
 
     def reset(self) -> None:
-        """Yeni çağrı başlarken state'i sıfırla."""
+        """Reset state at the start of a new invocation."""
         ...
 
     def can_initiate(self, obs: Observation) -> bool:
         """
-        Initiation set kontrolü.
-        Şimdilik her state'den başlatılabilir → her zaman True döner.
-        ⚠️ İleride kısıtlanabilir.
+        Initiation set check.
+        Currently always True — option can start from any state.
         """
         return True
 ```
 
-**Notlar:**
-- `terminated=True` → meta-controller kontrolü geri alır
-- Termination stratejisi (sabit limit / öğrenilen / GRU sinyali) bu sınıf içinde kapsüllenir
-- `step_count` sabit limit stratejisi için kullanılır
+**Notes:**
+- `terminated=True` → MetaController regains control
+- Termination strategy (fixed step limit / learned / GRU signal) is encapsulated inside Option
+- `step_count` is used by the fixed step limit strategy
 
 ---
 
-## Modül 5: Meta-Controller
+## Module 5: Meta-Controller
 
-**Sorumluluğu:** "Hangi option'ı ne zaman çağırmalıyım?"
+**Responsibility:** "Which option should I call, and when?"
 
 ```python
 @dataclass
 class MetaControllerOutput:
-    selected_option_id: int           # hangi option seçildi
-    option: Option                    # seçilen option referansı
+    selected_option_id: int
+    option: Option
 
 class MetaController:
-    n: LayerIdx                       # bu meta-controller hangi katmanı yönetiyor
-    available_options: list[Option]   # mevcut option listesi
+    n: LayerIdx                       # which layer this MC manages
+    available_options: list[Option]
 
     def select_option(self, obs: Observation) -> MetaControllerOutput:
-        """PPO policy ile option seç."""
+        """Select an option using PPO policy."""
         ...
 
     def add_option(self, option: Option) -> None:
         """
-        Yeni sütun stabilize olunca çağrılır.
-        Exploration bonus ile yeni option'ın keşfedilmesi sağlanır.
+        Called when a new column stabilizes.
+        Uses exploration bonus to encourage discovery of the new option.
+        Does NOT retrain from scratch.
         """
         ...
 
     def step(self, obs: Observation, reward: float, done: bool) -> None:
-        """PPO güncelleme adımı."""
+        """PPO update step."""
         ...
 ```
 
-**Notlar:**
-- Meta-controller'ın reward sinyali alt katman reward'larından **ayrı** tutulur — merge edilmez 🔒
-- `add_option()` sıfırdan retraining tetiklemez, mevcut policy üzerine exploration bonus eklenir
-- Meta-controller kendisi de bir option olarak wrap edilebilir (recursive yapı için)
+**Notes:**
+- MetaController reward is kept **separate** from sub-policy rewards — never merged 🔒
+- `add_option()` does not trigger retraining — adds exploration bonus on top of existing policy
+- A MetaController can itself be wrapped as an Option (enables recursive hierarchy)
 
 ---
 
-## Modül 6: Task Lifecycle Manager
+## Module 6: Task Lifecycle Manager
 
-**Sorumluluğu:** Modüller arası orkestrasyon — "hangi modül ne zaman devreye giriyor?"
+**Responsibility:** Orchestration — controls which module is active and when
 
 ```python
 @dataclass
@@ -246,29 +246,29 @@ class TaskLifecycleManager:
 
     def step(self, obs: Observation) -> Action:
         """
-        Her env adımında çağrılır.
-        AE → GRU → meta-controller → option → action pipeline'ını yönetir.
+        Called every env step.
+        Runs the AE → GRU → MetaController → Option → action pipeline.
         """
         ...
 
     def on_novel_task_detected(self) -> None:
-        """AE is_novel=True döndürdüğünde. Yeni sütun sürecini başlatır."""
+        """Called when AE returns is_novel=True. Starts new column process."""
         ...
 
     def on_column_stabilized(self, column: Column) -> None:
-        """Sütun eğitimi tamamlanınca. Option wrap + meta-controller'a ekle."""
+        """Called when column training completes. Wraps as option, adds to MetaController."""
         ...
 
     def get_state(self) -> SystemState:
-        """Debug ve GUI için anlık sistem durumu."""
+        """Returns current system state for GUI and debugging."""
         ...
 ```
 
 ---
 
-## Modüller Arası Sinyal Akışı
+## Signal Flow
 
-### Giriş noktası (her adımda)
+### Entry point (every step)
 
 ```
 obs_t
@@ -280,22 +280,20 @@ obs_t
 [GRU]                                  on_novel_task_detected()
   │ task_id                                    │
   ▼                                            ▼
-[TaskLifecycleManager]                 yeni Column açılır
-  │                                    eğitilir → stabilize → option'a eklenir
+[TaskLifecycleManager]                 new Column opened
+  │                                    trained → stabilized → wrapped as option
   ▼
-[recursive_step(obs, root_mc)]  ← aşağıya bak
+[recursive_step(obs, root_mc)]  ← see below
 ```
 
 ### Recursive execution (unbounded)
-
-Unbounded yapı burada — her seviye aynı mantığı tekrarlar:
 
 ```
 recursive_step(obs, MetaController):
   │
   ▼
 MetaController.select_option(obs)
-  │ → Option seçildi (wraps Column {n, m})
+  │ → Option selected (wraps Column {n, m})
   ▼
 Option.step(obs):
   │
@@ -303,30 +301,30 @@ Option.step(obs):
   │     │
   │     └─ Column.forward(obs) → action
   │           └─ env.step(action) → reward, next_obs, done
-  │                 └─ MetaController.step(reward)  ← bu seviyenin MC'si güncellenir
+  │                 └─ MetaController.step(reward)
   │
   └─ Column.sub_layer == MetaController  (NON-LEAF)
         │
         └─ recursive_step(obs, Column.sub_layer)
-              │  (aynı akış bir alt seviyede tekrar çalışır)
+              │  (same flow runs one level deeper)
               ▼
-             ... (derinlik sınırsız)
+             ... (unbounded depth)
               │
-              └─ en alttaki leaf action üretir
-                    └─ action yukarı taşınır
-                          └─ her seviyenin MC'si kendi reward'ını alır
+              └─ deepest leaf produces action
+                    └─ action propagates upward
+                          └─ each level's MC receives its own reward
 ```
 
-**Kilit nokta:** `TaskLifecycleManager` sadece root `MetaController`'ı çağırır — altında kaç seviye olduğunu bilmez, bilmek zorunda değildir. Her seviye kendi altını yönetir. Yeni bir katman eklemek root tanımını değiştirmez, sadece bir Column'un `sub_layer` field'ı doldurulur.
+**Key point:** `TaskLifecycleManager` only calls the root `MetaController` — it does not know or care how many levels exist below. Each level manages its own sub-levels. Adding a new layer only requires setting a Column's `sub_layer` field — nothing at the root changes.
 
 ---
 
-## Önemli Kısıtlamalar
+## Hard Constraints
 
-| Kural | Açıklama |
+| Rule | Description |
 |---|---|
-| AE ve GRU sinyalleri ayrı | `reconstruction_error` ile `sub_policy_reward` hiçbir zaman tek threshold'a merge edilmez |
-| Frozen = forward pass aktif | `frozen=True` sadece gradient'ı keser, aktivasyon üretimi devam eder |
-| Option stabilizasyon zorunlu | Yarı eğitimli sütun meta-controller'a eklenmez |
-| Reward sinyalleri ayrı | Alt katman reward'ı ile meta-controller reward'ı ayrı kanalda tutulur |
-| Recursive tasarım baştan | `sub_layer` field'ı Phase 1'de `None` olsa bile class'ta var olmalı |
+| AE and reward signals are separate | `reconstruction_error` and `sub_policy_reward` are never merged into a single threshold |
+| Frozen = forward pass still active | `frozen=True` only blocks gradients — activations are still produced |
+| Stabilization required before adding option | A column that has not stabilized must not be added to MetaController |
+| Reward channels are separate | Sub-policy reward and MetaController reward travel on separate channels |
+| Recursive design from the start | `sub_layer` field must exist on Column even if `None` in Phase 1 |

--- a/docs/ENS491_Module_Interfaces.md
+++ b/docs/ENS491_Module_Interfaces.md
@@ -1,0 +1,332 @@
+# ENS 491 — Modül Interface Spesifikasyonu
+
+> Her modülün input/output kontratı. Paralel geliştirmede bu doküman referans.  
+> Bir modülün içi değişebilir — ama bu kontrattan sapılmaz.  
+> Değişiklik gerekirse önce burası güncellenir, sonra kod.
+
+---
+
+## Genel Tipler
+
+```python
+import torch
+import numpy as np
+from dataclasses import dataclass
+from typing import Optional
+
+# MiniGrid observation: 7×7×3 uint8 array (FlatObsWrapper sonrası 147-dim float vector)
+Observation = torch.Tensor       # shape: (147,) — flattened
+ObsSequence  = torch.Tensor       # shape: (N, 147) — son N gözlem
+Action       = int                # discrete: 0-6 (MiniGrid action space)
+TaskID       = int                # 0-indexed, -1 = bilinmiyor
+LayerIdx     = int                # n — hiyerarşi katmanı
+ColumnIdx    = int                # m — katman içi sütun sırası
+```
+
+---
+
+## Modül 1: Autoencoder (AE)
+
+**Sorumluluğu:** "Bu gözlemi daha önce gördüm mü?"
+
+```python
+@dataclass
+class AEOutput:
+    reconstruction_error: float       # MSE — düşük = tanıdık, yüksek = yabancı
+    is_novel: bool                    # error > threshold ise True
+    latent_z: torch.Tensor            # shape: (latent_dim,) — downstream kullanım için
+
+class AutoencoderModule:
+    def encode(self, obs: Observation) -> torch.Tensor:
+        """Gözlemi latent space'e sıkıştır."""
+        ...
+
+    def decode(self, z: torch.Tensor) -> Observation:
+        """Latent vektörden gözlemi yeniden oluştur."""
+        ...
+
+    def forward(self, obs: Observation) -> AEOutput:
+        """Ana interface. Her adımda çağrılan metot."""
+        ...
+
+    def update_threshold(self, recent_errors: list[float]) -> None:
+        """Threshold güncelleme — adaptive stratejiler için."""
+        ...
+```
+
+**Notlar:**
+- `is_novel = True` → GRU'ya geçme, yeni sütun sürecini başlat
+- `is_novel = False` → GRU devreye girer
+- `latent_z` şimdilik kullanılmayabilir ama downstream (GRU input, task representation) için hazır tutulur
+- Threshold stratejisi (sabit / adaptive / istatistiksel) AE içinde kapsüllenir — dışarıdan sadece `is_novel` görünür
+
+---
+
+## Modül 2: GRU Task Identifier
+
+**Sorumluluğu:** "Bu hangi görev?"
+
+```python
+@dataclass
+class GRUOutput:
+    task_id: TaskID                   # tahmin edilen görev ID'si (-1 = belirsiz)
+    confidence: float                 # [0.0, 1.0]
+    all_probs: torch.Tensor           # shape: (num_known_tasks,) — softmax çıktısı
+
+class GRUTaskIdentifier:
+    def forward(self, obs_sequence: ObsSequence) -> GRUOutput:
+        """Son N gözlemi al, görev tahmin et."""
+        ...
+
+    def register_new_task(self, task_id: TaskID) -> None:
+        """Yeni görev öğrenilince çıktı boyutunu güncelle."""
+        ...
+```
+
+**Notlar:**
+- `obs_sequence` son N adımın gözlemleri — N hyperparameter (5 / 20 / 50 empirik karşılaştırılacak)
+- `task_id = -1` → GRU emin değil, sistemin davranışı TBD (⚠️ supervisor onayı)
+- AE `is_novel = False` dediğinde GRU çağrılır — AE `is_novel = True` dediğinde GRU çağrılmaz
+- Phase 1'de supervised (label'lı), sonraki aşamada label-free geçiş denenecek
+
+---
+
+## Modül 3: Progressive Networks Column
+
+**Sorumluluğu:** "Bu görevi nasıl yaparım?" + lateral transfer sağla
+
+```python
+@dataclass
+class ColumnOutput:
+    action: Action                              # seçilen eylem
+    value: float                                # PPO value estimate
+    activations: dict[int, torch.Tensor]        # katman_idx → aktivasyon (lateral için)
+
+class Column:
+    n: LayerIdx
+    m: ColumnIdx
+    frozen: bool
+    lateral_source: Optional['Column']          # {n, m-1} referansı, None ise ilk sütun
+    sub_layer: Optional['MetaController']       # None ise leaf (primitive), varsa recursive
+
+    def forward(self, obs: Observation) -> ColumnOutput:
+        """
+        İki farklı davranış — sub_layer'a göre ayrışır:
+
+        Leaf (sub_layer=None):
+            - Gözlemi işle, doğrudan action üret.
+            - lateral_source varsa aktivasyonlarını çek ve entegre et.
+            - frozen=True ise gradient hesaplanmaz.
+
+        Non-leaf (sub_layer=MetaController):
+            - Bu Column kendi action'ını üretmez.
+            - sub_layer.select_option(obs) çağrılır.
+            - Seçilen option kendi forward()'ını çalıştırır (recursive).
+            - En alttaki leaf'ten gelen action yukarı taşınır.
+            - Bu Column'un policy ağırlıkları meta-controller eğitimi için kullanılır,
+              doğrudan env action için değil.
+        """
+        ...
+
+    def freeze(self) -> None:
+        """Ağırlıkları dondur. Eğitim tamamlanınca çağrılır."""
+        ...
+
+    def get_activations(self) -> dict[int, torch.Tensor]:
+        """Son forward pass'in ara katman aktivasyonları. Lateral için."""
+        ...
+
+    def as_option(self) -> 'Option':
+        """Bu sütunu Option olarak wrap et."""
+        ...
+```
+
+**Notlar:**
+- `frozen=True` → gradient yok, ama forward pass çalışır (lateral bağlantılar için gerekli) 🔒
+- `activations` dict'i `get_activations()` ile bir sonraki sütun tarafından okunur
+- `sub_layer=None` → leaf node (n=0, primitive skill)
+- `sub_layer=MetaController(...)` → bu sütun hem policy hem bir alt hiyerarşiyi yönetiyor
+
+---
+
+## Modül 4: Option Wrapper
+
+**Sorumluluğu:** Sütunu Sutton et al. (1999) option formatına çevir
+
+```python
+@dataclass
+class OptionStepOutput:
+    action: Action
+    terminated: bool        # bu adımda option bitti mi?
+    info: dict              # debug bilgisi — adım sayısı, internal reward vs.
+
+class Option:
+    column: Column
+    option_id: int
+    step_count: int         # kaç adımdır çalışıyor
+
+    def step(self, obs: Observation) -> OptionStepOutput:
+        """Bir adım çalıştır, termination kontrol et."""
+        ...
+
+    def reset(self) -> None:
+        """Yeni çağrı başlarken state'i sıfırla."""
+        ...
+
+    def can_initiate(self, obs: Observation) -> bool:
+        """
+        Initiation set kontrolü.
+        Şimdilik her state'den başlatılabilir → her zaman True döner.
+        ⚠️ İleride kısıtlanabilir.
+        """
+        return True
+```
+
+**Notlar:**
+- `terminated=True` → meta-controller kontrolü geri alır
+- Termination stratejisi (sabit limit / öğrenilen / GRU sinyali) bu sınıf içinde kapsüllenir
+- `step_count` sabit limit stratejisi için kullanılır
+
+---
+
+## Modül 5: Meta-Controller
+
+**Sorumluluğu:** "Hangi option'ı ne zaman çağırmalıyım?"
+
+```python
+@dataclass
+class MetaControllerOutput:
+    selected_option_id: int           # hangi option seçildi
+    option: Option                    # seçilen option referansı
+
+class MetaController:
+    n: LayerIdx                       # bu meta-controller hangi katmanı yönetiyor
+    available_options: list[Option]   # mevcut option listesi
+
+    def select_option(self, obs: Observation) -> MetaControllerOutput:
+        """PPO policy ile option seç."""
+        ...
+
+    def add_option(self, option: Option) -> None:
+        """
+        Yeni sütun stabilize olunca çağrılır.
+        Exploration bonus ile yeni option'ın keşfedilmesi sağlanır.
+        """
+        ...
+
+    def step(self, obs: Observation, reward: float, done: bool) -> None:
+        """PPO güncelleme adımı."""
+        ...
+```
+
+**Notlar:**
+- Meta-controller'ın reward sinyali alt katman reward'larından **ayrı** tutulur — merge edilmez 🔒
+- `add_option()` sıfırdan retraining tetiklemez, mevcut policy üzerine exploration bonus eklenir
+- Meta-controller kendisi de bir option olarak wrap edilebilir (recursive yapı için)
+
+---
+
+## Modül 6: Task Lifecycle Manager
+
+**Sorumluluğu:** Modüller arası orkestrasyon — "hangi modül ne zaman devreye giriyor?"
+
+```python
+@dataclass
+class SystemState:
+    current_task_id: TaskID
+    active_column: Optional[Column]
+    active_option: Optional[Option]
+    is_training: bool
+
+class TaskLifecycleManager:
+    ae: AutoencoderModule
+    gru: GRUTaskIdentifier
+    columns: dict[tuple[LayerIdx, ColumnIdx], Column]
+    meta_controllers: dict[LayerIdx, MetaController]
+
+    def step(self, obs: Observation) -> Action:
+        """
+        Her env adımında çağrılır.
+        AE → GRU → meta-controller → option → action pipeline'ını yönetir.
+        """
+        ...
+
+    def on_novel_task_detected(self) -> None:
+        """AE is_novel=True döndürdüğünde. Yeni sütun sürecini başlatır."""
+        ...
+
+    def on_column_stabilized(self, column: Column) -> None:
+        """Sütun eğitimi tamamlanınca. Option wrap + meta-controller'a ekle."""
+        ...
+
+    def get_state(self) -> SystemState:
+        """Debug ve GUI için anlık sistem durumu."""
+        ...
+```
+
+---
+
+## Modüller Arası Sinyal Akışı
+
+### Giriş noktası (her adımda)
+
+```
+obs_t
+  │
+  ▼
+[AE]──────────────────────────────────────────┐
+  │ is_novel=False                             │ is_novel=True
+  ▼                                            ▼
+[GRU]                                  on_novel_task_detected()
+  │ task_id                                    │
+  ▼                                            ▼
+[TaskLifecycleManager]                 yeni Column açılır
+  │                                    eğitilir → stabilize → option'a eklenir
+  ▼
+[recursive_step(obs, root_mc)]  ← aşağıya bak
+```
+
+### Recursive execution (unbounded)
+
+Unbounded yapı burada — her seviye aynı mantığı tekrarlar:
+
+```
+recursive_step(obs, MetaController):
+  │
+  ▼
+MetaController.select_option(obs)
+  │ → Option seçildi (wraps Column {n, m})
+  ▼
+Option.step(obs):
+  │
+  ├─ Column.sub_layer == None  (LEAF)
+  │     │
+  │     └─ Column.forward(obs) → action
+  │           └─ env.step(action) → reward, next_obs, done
+  │                 └─ MetaController.step(reward)  ← bu seviyenin MC'si güncellenir
+  │
+  └─ Column.sub_layer == MetaController  (NON-LEAF)
+        │
+        └─ recursive_step(obs, Column.sub_layer)
+              │  (aynı akış bir alt seviyede tekrar çalışır)
+              ▼
+             ... (derinlik sınırsız)
+              │
+              └─ en alttaki leaf action üretir
+                    └─ action yukarı taşınır
+                          └─ her seviyenin MC'si kendi reward'ını alır
+```
+
+**Kilit nokta:** `TaskLifecycleManager` sadece root `MetaController`'ı çağırır — altında kaç seviye olduğunu bilmez, bilmek zorunda değildir. Her seviye kendi altını yönetir. Yeni bir katman eklemek root tanımını değiştirmez, sadece bir Column'un `sub_layer` field'ı doldurulur.
+
+---
+
+## Önemli Kısıtlamalar
+
+| Kural | Açıklama |
+|---|---|
+| AE ve GRU sinyalleri ayrı | `reconstruction_error` ile `sub_policy_reward` hiçbir zaman tek threshold'a merge edilmez |
+| Frozen = forward pass aktif | `frozen=True` sadece gradient'ı keser, aktivasyon üretimi devam eder |
+| Option stabilizasyon zorunlu | Yarı eğitimli sütun meta-controller'a eklenmez |
+| Reward sinyalleri ayrı | Alt katman reward'ı ile meta-controller reward'ı ayrı kanalda tutulur |
+| Recursive tasarım baştan | `sub_layer` field'ı Phase 1'de `None` olsa bile class'ta var olmalı |

--- a/docs/ENS491_Project_State.md
+++ b/docs/ENS491_Project_State.md
@@ -1,131 +1,130 @@
 # ENS 491 — Project State & Roadmap
 
-> Bu doküman projenin teknik hafızası. Ekip toplantılarında, supervisor görüşmelerinde ve implementasyon kararlarında referans nokta bu.
+> Technical memory of the project. Reference point for team meetings, supervisor sessions, and implementation decisions.
 >
-> **Ne değişmez:** Kilitlenmiş mimari kararlar — bunlar tartışılmaz.  
-> **Ne empirik:** Tasarım alternatifleri — hepsini implement et, sonuçları karşılaştır, kazan.  
-> **Ne nerede:** Mevcut durum ve sıradaki adımlar.
+> **Fixed:** Locked architectural decisions — not open for debate.  
+> **Empirical:** Design alternatives — implement all, compare results, pick the winner.  
+> **Status:** Current state and next steps.
 
 ---
 
-## Story Points Referansı
+## Story Points Reference
 
-| SP | Anlam |
-|----|-------|
-| 1 | Trivial. Nasıl yapılacağı zaten biliniyor. |
-| 2 | Straightforward. Küçük belirsizlik. |
-| 3 | Moderate. Birkaç bilinmeyen var. |
-| 5 | Significant. Tasarım kararı + implementation birlikte. |
-| 8 | Complex. Birden fazla bilinmeyen, iterasyon gerektirir. |
-| 13 | Very complex. Muhtemelen alt görevlere bölünmeli. |
+| SP | Meaning |
+|----|---------|
+| 1 | Trivial. Already know exactly how to do it. |
+| 2 | Straightforward. Minor unknowns. |
+| 3 | Moderate. A few unknowns. |
+| 5 | Significant. Design decision + implementation together. |
+| 8 | Complex. Multiple unknowns, requires iteration. |
+| 13 | Very complex. Should probably be broken into subtasks. |
 
 ---
 
-## Kilitlenmiş Mimari Kararlar
+## Locked Architectural Decisions
 
-Bunlar tartışmaya kapalı. Değiştirilmesi gerekirse önce supervisor onayı, sonra bu dokümanı güncelle.
+Not open for debate. If a change is needed, get supervisor approval first, then update this document.
 
 ### Continual Learning Backbone: Progressive Networks
 
-- Her görev için ayrı sütun (`{n, m}` notasyonu: `n` = katman, `m` = sütun sayısı)
-- Sütun eğitimi bitince ağırlıklar **dondurulur** — bir daha değişmez
-- Lateral bağlantılar **aynı meta-controller'ın çocukları arasında** tanımlı: `{n, m-1} → {n, m}`
-- Sütun sayısı ve katman sayısı **runtime'da büyür** — mimari baştan recursive/unbounded olarak tasarlanır
-- Implementation yolu: Doric → custom PN → mimariye özgün custom PN (bu sıra atlanamaz)
+- Separate column per task (`{n, m}` notation: `n` = layer, `m` = column count)
+- Column weights are **frozen** after training — never modified again
+- Lateral connections defined **between children of the same meta-controller**: `{n, m-1} → {n, m}`
+- Column count and layer count **grow at runtime** — architecture is recursive/unbounded from the start
+- Implementation path: Doric → custom PN → architecture-specific custom PN (this order cannot be skipped)
 
-### Hierarchy Yapısı
+### Hierarchy Structure
 
-- Hiyerarşi **ağaç değil, DAG** — aynı primitif sütunlar birden fazla meta-controller tarafından paylaşılabilir (supervisor onayı bekleniyor ama tasarım buna göre yapılıyor)
-- Her katmanın meta-controller'ı **yalnızca kendi katmanını** görür
-- Hiyerarşi **derinliği sabit değil** — yeni katman runtime'da açılabilir
-- `{n, m}` notasyonu: `n` arttıkça soyutlama seviyesi artar, `m` o katmandaki sütun sayısı
+- Hierarchy is implemented as a **tree** — each primitive column belongs to exactly one meta-controller
+- Each layer's meta-controller **only sees its own layer**
+- Hierarchy **depth is not fixed** — new layers can open at runtime
+- `{n, m}` notation: higher `n` = higher abstraction, `m` = column count at that layer
 
 ### Task Detection
 
-- **Reconstruction error** → observation-level novelty sinyali (yeni görev var mı?)
-- **Sub-policy reward** → behavioral insufficiency sinyali (mevcut policy yeterli mi?)
-- Bu iki sinyal **birbirinden bağımsız** tutulur, merge edilmez
-- AE ve GRU pipeline'da sıralı: AE "yeni mi?" sorusunu, GRU "hangisi?" sorusunu cevaplar
+- **Reconstruction error** → observation-level novelty signal (is there a new task?)
+- **Sub-policy reward** → behavioral insufficiency signal (is the current policy sufficient?)
+- These two signals are kept **independent** — never merged
+- AE and GRU are sequential in the pipeline: AE answers "is it new?", GRU answers "which one?"
 
 ### Options Framework
 
-- Her eğitilmiş sütun bir **option** olarak wrap edilir (Sutton et al. 1999)
-- Options **stabilize olduktan sonra** meta-controller'a eklenir — yarı eğitimli option eklenmez
-- Meta-controller **PPO** ile eğitilir (SB3)
-- Yeni option eklenince meta-controller sıfırdan eğitilmez — exploration bonus ile keşfetmesi sağlanır
+- Every trained column is **wrapped as an option** (Sutton et al. 1999)
+- Options are added to MetaController only **after stabilization** — no half-trained options
+- MetaController is trained with **PPO** (SB3)
+- When a new option is added, MetaController is not retrained from scratch — exploration bonus is used instead
 
 ### Stack
 
 - Python 3.10, PyTorch + CUDA, MiniGrid (Gymnasium), Stable-Baselines3
-- `FlatObsWrapper + MlpPolicy` — CnnPolicy MiniGrid'de çalışmıyor (7×7 obs vs 8×8 kernel)
-- Birincil test ortamı: MiniGrid (Empty → FourRooms → DoorKey → KeyCorridor)
+- `FlatObsWrapper + MlpPolicy` — CnnPolicy does not work on MiniGrid (7×7 obs vs 8×8 kernel)
+- Primary test environment: MiniGrid (Empty → FourRooms → DoorKey → KeyCorridor)
 - Experiment tracking: Weights & Biases
 
 ---
 
-## Açık Empirik Sorular
+## Open Empirical Questions
 
-Bunlar için "doğru cevap" önceden belli değil. Her alternatifi implement et, karşılaştır.
+No predetermined correct answer. Implement each alternative, compare.
 
-### AE Mimarisi
+### AE Architecture
 `Undercomplete AE` → `Sparse AE` → `VQ-VAE`  
-Kriter: task boundary'de reconstruction error ne kadar keskin sıçrıyor?  
-Referans: Meyer et al. (2024) — aynı karşılaştırmayı MiniGrid'e replicate et.
+Criterion: how sharply does reconstruction error spike at task boundaries?  
+Reference: Meyer et al. (2024) — replicate their comparison on MiniGrid.
 
 ### AE Threshold
-`Sabit global` → `Per-task adaptive` → `Statistical test (KS / Wasserstein)`  
-Referans: Dick et al. 2024 (SWOKS) MiniGrid + PPO'da bunu yapıyor.
+`Fixed global` → `Per-task adaptive` → `Statistical test (KS / Wasserstein)`  
+Reference: Dick et al. 2024 (SWOKS) — does this on MiniGrid + PPO.
 
-### AE Güncelleme Protokolü
-`Tek global AE, fine-tune` → `Per-task ayrı AE` → `Frozen shared encoder + task-specific head`  
-Ayrıca baseline: AE hiç güncellenmiyor — ne kadar bozuluyor?
+### AE Update Protocol
+`Single global AE, fine-tune` → `Per-task separate AE` → `Frozen shared encoder + task-specific head`  
+Also run: AE never updated — how much does performance degrade?
 
-### GRU Sequence Uzunluğu
+### GRU Sequence Length
 `N=5` → `N=20` → `N=50`  
-Kriter: classification accuracy vs task-switching latency trade-off.
+Criterion: classification accuracy vs task-switching latency trade-off.
 
-### GRU Training Paradigması
-`Supervised (label'lı)` → `Contrastive (SimCLR tarzı)` → `Clustering (DBSCAN)`  
-Supervised zorunlu başlangıç noktası — label-free geçiş araştırma sorusu.
+### GRU Training Paradigm
+`Supervised (labeled)` → `Contrastive (SimCLR-style)` → `Clustering (DBSCAN)`  
+Supervised is the mandatory starting point. Label-free transition is a research question.
 
 ### Meta-Controller Sparse Reward
 `Sub-goal completion bonus` → `Potential-based shaping` → `Intrinsic curiosity`  
-Kriter: convergence hızı ve final performance.
+Criterion: convergence speed and final performance.
 
 ### Termination Condition
-`Sabit adım limiti` → `Öğrenilen termination (Option-Critic tarzı)` → `GRU task-change sinyali`
+`Fixed step limit` → `Learned termination (Option-Critic style)` → `GRU task-change signal`
 
-### Yeni Sütun Açma Sinyali
-`Sadece AE threshold` → `Sadece reward plateau` → `AND` → `OR`  
-Her kombinasyonu aynı görev sırasında çalıştır, gereksiz sütun açılma oranını ölç.
+### New Column Trigger
+`AE threshold only` → `Reward plateau only` → `AND` → `OR`  
+Run each combination on the same task sequence, measure unnecessary column openings.
 
-### Görev Sırası
-`Easy→Hard` → `Hard→Easy` → `Benzer önce` → `İzole önce`  
-Kriter: BWT, FWT, Average Performance. Sıranın etkisi başlı başına bir bulgu.
+### Task Sequence
+`Easy→Hard` → `Hard→Easy` → `Similar first` → `Isolated first`  
+Criterion: BWT, FWT, Average Performance. Sequence effect is itself a finding.
 
 ---
 
-## Mevcut Durum
+## Current Status
 
-### ✅ Tamamlananlar
+### ✅ Done
 
-| Görev | Not |
+| Task | Notes |
 |---|---|
 | PPO baseline — Empty-8x8 | FlatObsWrapper + MlpPolicy, reward ~0.04 → ~0.91 |
-| Catastrophic forgetting gösterimi | Fine-tune → Empty'ye dön, performans düşüşü sayısal olarak görüldü |
-| Geliştirme ortamı | Windows + RTX 3070 Ti, CUDA 12.1, Miniconda ens491 env, SB3, MiniGrid |
-| GitHub sandbox reposu | `ens491-sandbox` aktif |
-| `doric_test.py` | Doric kütüphanesi ile tek sütunlu PN, lateral bağlantı mekanizması incelendi |
-| Proposal + literature review | 120+ paper, 7 kategori, Zotero entegrasyonu |
-| Takım onboarding dokümanı | Hizalama dokümanı tamamlandı |
+| Catastrophic forgetting demonstration | Fine-tune → return to Empty, performance drop measured |
+| Development environment | Windows + RTX 3070 Ti, CUDA 12.1, Miniconda ens491 env, SB3, MiniGrid |
+| GitHub sandbox repo | `ens491-sandbox` active |
+| `doric_test.py` | Doric library PN explored, lateral connection mechanism studied |
+| Proposal + literature review | 120+ papers, 7 categories, Zotero integration |
+| Team onboarding document | Alignment doc complete |
 
-### 🔄 Devam Eden
+### 🔄 In Progress
 
-| Görev | Durum |
+| Task | Status |
 |---|---|
-| Progressive Networks implementasyonu | Doric aşamasında. `custom_pn_test.py` henüz yazılmadı |
-| Recursive hierarchy tasarımı | Kağıt üzerinde kararlar alındı, koda yansımadı |
-| DAG yapısı supervisor onayı | Bekleniyor |
+| Progressive Networks implementation | At Doric stage. `custom_pn_test.py` not yet written |
+| Recursive hierarchy design | Paper decisions made, not yet reflected in code |
 
 ---
 
@@ -133,122 +132,111 @@ Kriter: BWT, FWT, Average Performance. Sıranın etkisi başlı başına bir bul
 
 ### Phase 1 — Continual Learning Core
 
-**Amaç:** PN bu stack'te çalışıyor mu? AE ve GRU bağımsız çalışıyor mu? Forgetting önleniyor mu?  
-Explicit task ID var. Bu phase çalışmadan Phase 2'ye geçmek anlamsız.
+**Goal:** Does PN work in this stack? Do AE and GRU work independently? Is forgetting prevented?  
+Explicit task ID present. If something doesn't work here, moving to Phase 2 is pointless.
 
 #### Progressive Networks
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
-| PN-1 | `custom_pn_test.py` — sadece PyTorch, iki sütun, bir lateral bağlantı, Empty üzerinde | 5 | ⬜ Sıradaki |
-| PN-2 | Doric vs custom PN karşılaştırması — hangisi recursive tasarıma daha doğal fit ediyor? | 3 | ⬜ |
-| PN-3 | Mimari-özgün custom PN — `{n,m}` notasyonu, runtime column growth, PPO + SB3 entegrasyonu | 13 | ⬜ |
-| PN-4 | İkinci sütun + FourRooms, lateral bağlantı aktivasyonunu görselleştir | 5 | ⬜ |
-| PN-5 | Forgetting testi: N görev sonra birinci göreve dön, performans ölç | 3 | ⬜ |
-| PN-6 | EWC baseline — aynı görev sırasında, paper için alt sınır | 5 | ⬜ |
-| PN-7 | DoorKey ile üçüncü sütun — N görevde scale ediyor mu? | 3 | ⬜ |
+| PN-1 | `custom_pn_test.py` — pure PyTorch, two columns, one lateral connection, on Empty | 5 | ⬜ Next |
+| PN-2 | Doric vs custom PN comparison — which fits the recursive design more naturally? | 3 | ⬜ |
+| PN-3 | Architecture-specific custom PN — `{n,m}` notation, runtime column growth, PPO + SB3 integration | 13 | ⬜ |
+| PN-4 | Second column + FourRooms, visualize lateral connection activations | 5 | ⬜ |
+| PN-5 | Forgetting test: return to first task after N tasks, measure retained performance | 3 | ⬜ |
+| PN-6 | EWC baseline — same task sequence, lower bound for paper | 5 | ⬜ |
+| PN-7 | Third column with DoorKey — does it scale to N tasks? | 3 | ⬜ |
 
-> **PN-3 öncesinde:** Recursive hierarchy tasarımını kod yazmadan önce kağıt üzerinde netleştir. DAG yapısı, meta-controller-to-meta-controller option çağrısı, termination propagation. Bu bir milestone — atlamak ileride rewrite anlamına gelir.
+> **Before PN-3:** Finalize recursive hierarchy design on paper before writing code. DAG structure, MC-to-MC option calling, termination propagation. This is a milestone — skipping it means a rewrite later.
 
 #### Autoencoder
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
 | AE-1 | Convolutional AE baseline — MiniGrid obs (7×7×3), encode/decode pipeline | 3 | ⬜ |
-| AE-2 | Threshold analizi — tanıdık vs yabancı görev error dağılımı, overlap ölç | 5 | ⬜ |
-| AE-3 | Mimari karşılaştırma: Undercomplete → Sparse AE → VQ-VAE (empirical) | 8 | ⬜ |
-| AE-4 | Güncelleme protokolü karşılaştırması: global fine-tune / per-task / frozen encoder (empirical) | 8 | ⬜ |
+| AE-2 | Threshold analysis — familiar vs novel task error distributions, measure overlap | 5 | ⬜ |
+| AE-3 | Architecture comparison: Undercomplete → Sparse AE → VQ-VAE (empirical) | 8 | ⬜ |
+| AE-4 | Update protocol comparison: global fine-tune / per-task / frozen encoder (empirical) | 8 | ⬜ |
 
 #### GRU
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
-| GRU-1 | Veri toplama pipeline — farklı task'lardan label'lı episode dizileri | 2 | ⬜ |
-| GRU-2 | Supervised baseline — N=5 vs N=20 vs N=50 karşılaştır (empirical) | 5 | ⬜ |
-| GRU-3 | Label-free geçiş denemesi: contrastive / clustering (araştırma sorusu, negatif sonuç da değerli) | 8 | ⬜ |
+| GRU-1 | Data collection pipeline — labeled episode observation sequences across tasks | 2 | ⬜ |
+| GRU-2 | Supervised baseline — compare N=5 vs N=20 vs N=50 (empirical) | 5 | ⬜ |
+| GRU-3 | Label-free transition attempt: contrastive / clustering (research question, negative result is also valuable) | 8 | ⬜ |
 
 #### Phase 1 Integration
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
-| INT-1 | AE + GRU handoff — AE "yeni" deyince GRU devreye giriyor mu? False positive/negative ölç | 5 | ⬜ |
+| INT-1 | AE + GRU handoff — when AE says "novel", does GRU step in correctly? Measure false positive/negative | 5 | ⬜ |
 
 ---
 
 ### Phase 2 — Hierarchical Control
 
-**Amaç:** Explicit task ID olmadan sistem görevi anlayabiliyor mu? Öğrendiği becerileri macro-action olarak kullanabiliyor mu?  
-Bu phase paper'ın asıl katkısı. Phase 2 tamamlanmış sistem publishable.
+**Goal:** Can the system understand tasks without explicit task IDs? Can it use learned skills as macro-actions?  
+This phase is the paper's core contribution. A completed Phase 2 system is publishable on its own.
 
-> Phase 2'ye başlamadan: recursive hierarchy kağıt tasarımı onaylanmış ve Phase 1 PN/AE/GRU çalışıyor olmalı.
+> Before Phase 2: recursive hierarchy paper design must be confirmed, and Phase 1 PN/AE/GRU must be working.
 
 #### Dynamic Options & Meta-Controller
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
-| OPT-1 | PoC: PN olmadan 2 frozen PPO + meta-controller — options framework çalışıyor mu? | 8 | ⬜ |
-| OPT-2 | PN sütunlarını option olarak wrap et — frozen column = option, termination test | 5 | ⬜ |
-| OPT-3 | Sparse reward stratejisi karşılaştırması: sub-goal bonus / potential-based / curiosity (empirical) | 8 | ⬜ |
-| OPT-4 | Yeni option eklenince keşif: exploration bonus vs optimistic initialization (empirical) | 5 | ⬜ |
-| OPT-5 | Termination condition karşılaştırması: sabit limit / öğrenilen / GRU sinyali (empirical) | 8 | ⬜ |
+| OPT-1 | PoC: 2 frozen PPO + meta-controller without PN — does the options framework work? | 8 | ⬜ |
+| OPT-2 | Wrap PN columns as options — frozen column = option, test termination | 5 | ⬜ |
+| OPT-3 | Sparse reward strategy comparison: sub-goal bonus / potential-based / curiosity (empirical) | 8 | ⬜ |
+| OPT-4 | New option discovery: exploration bonus vs optimistic initialization (empirical) | 5 | ⬜ |
+| OPT-5 | Termination condition comparison: fixed limit / learned / GRU signal (empirical) | 8 | ⬜ |
 
 #### Phase 2 Integration & Ablation
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
-| INT-2 | AE + GRU + PN + meta-controller end-to-end, explicit task ID kaldırıldı | 13 | ⬜ |
-| INT-3 | Ablation: AE kapalı | 3 | ⬜ |
-| INT-4 | Ablation: GRU kapalı | 3 | ⬜ |
-| INT-5 | Ablation: lateral bağlantılar kapalı | 3 | ⬜ |
-| INT-6 | Görev sırası karşılaştırması: 4 farklı sıra, aynı sistem (empirical) | 8 | ⬜ |
+| INT-2 | AE + GRU + PN + MetaController end-to-end, explicit task ID removed | 13 | ⬜ |
+| INT-3 | Ablation: AE disabled | 3 | ⬜ |
+| INT-4 | Ablation: GRU disabled | 3 | ⬜ |
+| INT-5 | Ablation: lateral connections disabled | 3 | ⬜ |
+| INT-6 | Task sequence comparison: 4 different orderings, same system (empirical) | 8 | ⬜ |
 
 ---
 
 ### Phase 3 — Planning (Stretch Goal)
 
-**Amaç:** Meta-controller reactive seçim yapmak yerine option graph üzerinde sequence planlayabiliyor mu?  
-Phase 2 stable olmadan başlanmaz. Paper Phase 2 sonuçlarına göre yazılıyor, Phase 3 ek katkı.
+**Goal:** Can the MetaController plan a sequence over the option graph rather than making reactive per-step selections?  
+Do not start until Phase 2 is stable. Paper is written from Phase 2 results; Phase 3 is additional contribution.
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
-| PLN-1 | Option transition graph inşa et — hangi option'dan sonra hangisi başarılı? | 8 | ⬜ |
-| PLN-2 | Lookahead ekle — reactive vs deliberative karşılaştırma | 13 | ⬜ |
-| PLN-3 | Multi-level hierarchy end-to-end: Level-2 meta-controller, iki seviye çalışıyor mu? | 13 | ⬜ |
+| PLN-1 | Build option transition graph — which options succeed after which? | 8 | ⬜ |
+| PLN-2 | Add lookahead — compare reactive vs deliberative | 13 | ⬜ |
+| PLN-3 | Multi-level hierarchy end-to-end: Level-2 MetaController, does two levels work? | 13 | ⬜ |
 
 ---
 
-### Phase 4 — Evaluation & Paper (Phase 2 ile Paralel)
+### Phase 4 — Evaluation & Paper (Parallel with Phase 2)
 
-| # | Görev | SP | Durum |
+| # | Task | SP | Status |
 |---|---|---|---|
-| EVAL-1 | W&B dashboard: reconstruction error, option frekansı, per-task reward canlı | 3 | ⬜ |
-| EVAL-2 | BWT / FWT / Average Performance utility — W&B'ye log'layan | 3 | ⬜ |
-| EVAL-3 | Streamlit minimal GUI: aktif sütun, option history, policy görselleştirme | 8 | ⬜ |
-| EVAL-4 | Full evaluation: 3+ görev sırası, tüm metrikler, baseline karşılaştırması | 8 | ⬜ |
-| EVAL-5 | Paper draft — Phase 2 sonuçlarıyla | 13 | ⬜ |
+| EVAL-1 | W&B dashboard: reconstruction error, option frequency, per-task reward live | 3 | ⬜ |
+| EVAL-2 | BWT / FWT / Average Performance utility — logs to W&B | 3 | ⬜ |
+| EVAL-3 | Minimal Streamlit GUI: active column, option history, policy visualization | 8 | ⬜ |
+| EVAL-4 | Full evaluation: 3+ task sequence, all metrics, baseline comparison | 8 | ⬜ |
+| EVAL-5 | Paper draft — from Phase 2 results | 13 | ⬜ |
 
 ---
 
-## Kritik Path
+## Critical Path
 
-Bu sıra bloklanırsa sistem bir araya gelemiyor:
+If this sequence is blocked, the system cannot be assembled:
 
 ```
 PN-1 → PN-2 → PN-3* → PN-4 → OPT-1 → OPT-2 → INT-2
                 ↑
-        Recursive hierarchy tasarım milestone (kağıt üzerinde)
+        Recursive hierarchy design milestone (on paper)
 ```
 
-Paralel başlanabilecekler (kritik path'i bloklamıyor):  
+Can be started in parallel (does not block critical path):  
 `AE-1, AE-2, GRU-1, GRU-2, EVAL-1, EVAL-2`
-
----
-
-## Supervisor'a Onaylatılacak Açık Sorular
-
-- [ ] DAG yapısı doğru mu? Aynı primitif sütunlar birden fazla meta-controller tarafından paylaşılabilir mi?
-- [ ] Meta-controller-to-meta-controller recursive option çağrısı ve termination propagation tam olarak nasıl çalışmalı?
-- [ ] Yeni görev yeni katman mı, yeni sütun mu açıyor? Bu kararı ne belirliyor?
-- [ ] GRU continual learning: EWC mi, accumulated data üzerinde retraining mi?
-- [ ] MiniGrid görev sırası onayı: Empty → FourRooms → DoorKey → KeyCorridor → custom multi-key
-- [ ] OPT-1 PoC yaklaşımı onaylandı mı? (frozen PPO policies + meta-controller, PN yok)

--- a/docs/ENS491_Project_State.md
+++ b/docs/ENS491_Project_State.md
@@ -1,0 +1,254 @@
+# ENS 491 — Project State & Roadmap
+
+> Bu doküman projenin teknik hafızası. Ekip toplantılarında, supervisor görüşmelerinde ve implementasyon kararlarında referans nokta bu.
+>
+> **Ne değişmez:** Kilitlenmiş mimari kararlar — bunlar tartışılmaz.  
+> **Ne empirik:** Tasarım alternatifleri — hepsini implement et, sonuçları karşılaştır, kazan.  
+> **Ne nerede:** Mevcut durum ve sıradaki adımlar.
+
+---
+
+## Story Points Referansı
+
+| SP | Anlam |
+|----|-------|
+| 1 | Trivial. Nasıl yapılacağı zaten biliniyor. |
+| 2 | Straightforward. Küçük belirsizlik. |
+| 3 | Moderate. Birkaç bilinmeyen var. |
+| 5 | Significant. Tasarım kararı + implementation birlikte. |
+| 8 | Complex. Birden fazla bilinmeyen, iterasyon gerektirir. |
+| 13 | Very complex. Muhtemelen alt görevlere bölünmeli. |
+
+---
+
+## Kilitlenmiş Mimari Kararlar
+
+Bunlar tartışmaya kapalı. Değiştirilmesi gerekirse önce supervisor onayı, sonra bu dokümanı güncelle.
+
+### Continual Learning Backbone: Progressive Networks
+
+- Her görev için ayrı sütun (`{n, m}` notasyonu: `n` = katman, `m` = sütun sayısı)
+- Sütun eğitimi bitince ağırlıklar **dondurulur** — bir daha değişmez
+- Lateral bağlantılar **aynı meta-controller'ın çocukları arasında** tanımlı: `{n, m-1} → {n, m}`
+- Sütun sayısı ve katman sayısı **runtime'da büyür** — mimari baştan recursive/unbounded olarak tasarlanır
+- Implementation yolu: Doric → custom PN → mimariye özgün custom PN (bu sıra atlanamaz)
+
+### Hierarchy Yapısı
+
+- Hiyerarşi **ağaç değil, DAG** — aynı primitif sütunlar birden fazla meta-controller tarafından paylaşılabilir (supervisor onayı bekleniyor ama tasarım buna göre yapılıyor)
+- Her katmanın meta-controller'ı **yalnızca kendi katmanını** görür
+- Hiyerarşi **derinliği sabit değil** — yeni katman runtime'da açılabilir
+- `{n, m}` notasyonu: `n` arttıkça soyutlama seviyesi artar, `m` o katmandaki sütun sayısı
+
+### Task Detection
+
+- **Reconstruction error** → observation-level novelty sinyali (yeni görev var mı?)
+- **Sub-policy reward** → behavioral insufficiency sinyali (mevcut policy yeterli mi?)
+- Bu iki sinyal **birbirinden bağımsız** tutulur, merge edilmez
+- AE ve GRU pipeline'da sıralı: AE "yeni mi?" sorusunu, GRU "hangisi?" sorusunu cevaplar
+
+### Options Framework
+
+- Her eğitilmiş sütun bir **option** olarak wrap edilir (Sutton et al. 1999)
+- Options **stabilize olduktan sonra** meta-controller'a eklenir — yarı eğitimli option eklenmez
+- Meta-controller **PPO** ile eğitilir (SB3)
+- Yeni option eklenince meta-controller sıfırdan eğitilmez — exploration bonus ile keşfetmesi sağlanır
+
+### Stack
+
+- Python 3.10, PyTorch + CUDA, MiniGrid (Gymnasium), Stable-Baselines3
+- `FlatObsWrapper + MlpPolicy` — CnnPolicy MiniGrid'de çalışmıyor (7×7 obs vs 8×8 kernel)
+- Birincil test ortamı: MiniGrid (Empty → FourRooms → DoorKey → KeyCorridor)
+- Experiment tracking: Weights & Biases
+
+---
+
+## Açık Empirik Sorular
+
+Bunlar için "doğru cevap" önceden belli değil. Her alternatifi implement et, karşılaştır.
+
+### AE Mimarisi
+`Undercomplete AE` → `Sparse AE` → `VQ-VAE`  
+Kriter: task boundary'de reconstruction error ne kadar keskin sıçrıyor?  
+Referans: Meyer et al. (2024) — aynı karşılaştırmayı MiniGrid'e replicate et.
+
+### AE Threshold
+`Sabit global` → `Per-task adaptive` → `Statistical test (KS / Wasserstein)`  
+Referans: Dick et al. 2024 (SWOKS) MiniGrid + PPO'da bunu yapıyor.
+
+### AE Güncelleme Protokolü
+`Tek global AE, fine-tune` → `Per-task ayrı AE` → `Frozen shared encoder + task-specific head`  
+Ayrıca baseline: AE hiç güncellenmiyor — ne kadar bozuluyor?
+
+### GRU Sequence Uzunluğu
+`N=5` → `N=20` → `N=50`  
+Kriter: classification accuracy vs task-switching latency trade-off.
+
+### GRU Training Paradigması
+`Supervised (label'lı)` → `Contrastive (SimCLR tarzı)` → `Clustering (DBSCAN)`  
+Supervised zorunlu başlangıç noktası — label-free geçiş araştırma sorusu.
+
+### Meta-Controller Sparse Reward
+`Sub-goal completion bonus` → `Potential-based shaping` → `Intrinsic curiosity`  
+Kriter: convergence hızı ve final performance.
+
+### Termination Condition
+`Sabit adım limiti` → `Öğrenilen termination (Option-Critic tarzı)` → `GRU task-change sinyali`
+
+### Yeni Sütun Açma Sinyali
+`Sadece AE threshold` → `Sadece reward plateau` → `AND` → `OR`  
+Her kombinasyonu aynı görev sırasında çalıştır, gereksiz sütun açılma oranını ölç.
+
+### Görev Sırası
+`Easy→Hard` → `Hard→Easy` → `Benzer önce` → `İzole önce`  
+Kriter: BWT, FWT, Average Performance. Sıranın etkisi başlı başına bir bulgu.
+
+---
+
+## Mevcut Durum
+
+### ✅ Tamamlananlar
+
+| Görev | Not |
+|---|---|
+| PPO baseline — Empty-8x8 | FlatObsWrapper + MlpPolicy, reward ~0.04 → ~0.91 |
+| Catastrophic forgetting gösterimi | Fine-tune → Empty'ye dön, performans düşüşü sayısal olarak görüldü |
+| Geliştirme ortamı | Windows + RTX 3070 Ti, CUDA 12.1, Miniconda ens491 env, SB3, MiniGrid |
+| GitHub sandbox reposu | `ens491-sandbox` aktif |
+| `doric_test.py` | Doric kütüphanesi ile tek sütunlu PN, lateral bağlantı mekanizması incelendi |
+| Proposal + literature review | 120+ paper, 7 kategori, Zotero entegrasyonu |
+| Takım onboarding dokümanı | Hizalama dokümanı tamamlandı |
+
+### 🔄 Devam Eden
+
+| Görev | Durum |
+|---|---|
+| Progressive Networks implementasyonu | Doric aşamasında. `custom_pn_test.py` henüz yazılmadı |
+| Recursive hierarchy tasarımı | Kağıt üzerinde kararlar alındı, koda yansımadı |
+| DAG yapısı supervisor onayı | Bekleniyor |
+
+---
+
+## Roadmap
+
+### Phase 1 — Continual Learning Core
+
+**Amaç:** PN bu stack'te çalışıyor mu? AE ve GRU bağımsız çalışıyor mu? Forgetting önleniyor mu?  
+Explicit task ID var. Bu phase çalışmadan Phase 2'ye geçmek anlamsız.
+
+#### Progressive Networks
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| PN-1 | `custom_pn_test.py` — sadece PyTorch, iki sütun, bir lateral bağlantı, Empty üzerinde | 5 | ⬜ Sıradaki |
+| PN-2 | Doric vs custom PN karşılaştırması — hangisi recursive tasarıma daha doğal fit ediyor? | 3 | ⬜ |
+| PN-3 | Mimari-özgün custom PN — `{n,m}` notasyonu, runtime column growth, PPO + SB3 entegrasyonu | 13 | ⬜ |
+| PN-4 | İkinci sütun + FourRooms, lateral bağlantı aktivasyonunu görselleştir | 5 | ⬜ |
+| PN-5 | Forgetting testi: N görev sonra birinci göreve dön, performans ölç | 3 | ⬜ |
+| PN-6 | EWC baseline — aynı görev sırasında, paper için alt sınır | 5 | ⬜ |
+| PN-7 | DoorKey ile üçüncü sütun — N görevde scale ediyor mu? | 3 | ⬜ |
+
+> **PN-3 öncesinde:** Recursive hierarchy tasarımını kod yazmadan önce kağıt üzerinde netleştir. DAG yapısı, meta-controller-to-meta-controller option çağrısı, termination propagation. Bu bir milestone — atlamak ileride rewrite anlamına gelir.
+
+#### Autoencoder
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| AE-1 | Convolutional AE baseline — MiniGrid obs (7×7×3), encode/decode pipeline | 3 | ⬜ |
+| AE-2 | Threshold analizi — tanıdık vs yabancı görev error dağılımı, overlap ölç | 5 | ⬜ |
+| AE-3 | Mimari karşılaştırma: Undercomplete → Sparse AE → VQ-VAE (empirical) | 8 | ⬜ |
+| AE-4 | Güncelleme protokolü karşılaştırması: global fine-tune / per-task / frozen encoder (empirical) | 8 | ⬜ |
+
+#### GRU
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| GRU-1 | Veri toplama pipeline — farklı task'lardan label'lı episode dizileri | 2 | ⬜ |
+| GRU-2 | Supervised baseline — N=5 vs N=20 vs N=50 karşılaştır (empirical) | 5 | ⬜ |
+| GRU-3 | Label-free geçiş denemesi: contrastive / clustering (araştırma sorusu, negatif sonuç da değerli) | 8 | ⬜ |
+
+#### Phase 1 Integration
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| INT-1 | AE + GRU handoff — AE "yeni" deyince GRU devreye giriyor mu? False positive/negative ölç | 5 | ⬜ |
+
+---
+
+### Phase 2 — Hierarchical Control
+
+**Amaç:** Explicit task ID olmadan sistem görevi anlayabiliyor mu? Öğrendiği becerileri macro-action olarak kullanabiliyor mu?  
+Bu phase paper'ın asıl katkısı. Phase 2 tamamlanmış sistem publishable.
+
+> Phase 2'ye başlamadan: recursive hierarchy kağıt tasarımı onaylanmış ve Phase 1 PN/AE/GRU çalışıyor olmalı.
+
+#### Dynamic Options & Meta-Controller
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| OPT-1 | PoC: PN olmadan 2 frozen PPO + meta-controller — options framework çalışıyor mu? | 8 | ⬜ |
+| OPT-2 | PN sütunlarını option olarak wrap et — frozen column = option, termination test | 5 | ⬜ |
+| OPT-3 | Sparse reward stratejisi karşılaştırması: sub-goal bonus / potential-based / curiosity (empirical) | 8 | ⬜ |
+| OPT-4 | Yeni option eklenince keşif: exploration bonus vs optimistic initialization (empirical) | 5 | ⬜ |
+| OPT-5 | Termination condition karşılaştırması: sabit limit / öğrenilen / GRU sinyali (empirical) | 8 | ⬜ |
+
+#### Phase 2 Integration & Ablation
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| INT-2 | AE + GRU + PN + meta-controller end-to-end, explicit task ID kaldırıldı | 13 | ⬜ |
+| INT-3 | Ablation: AE kapalı | 3 | ⬜ |
+| INT-4 | Ablation: GRU kapalı | 3 | ⬜ |
+| INT-5 | Ablation: lateral bağlantılar kapalı | 3 | ⬜ |
+| INT-6 | Görev sırası karşılaştırması: 4 farklı sıra, aynı sistem (empirical) | 8 | ⬜ |
+
+---
+
+### Phase 3 — Planning (Stretch Goal)
+
+**Amaç:** Meta-controller reactive seçim yapmak yerine option graph üzerinde sequence planlayabiliyor mu?  
+Phase 2 stable olmadan başlanmaz. Paper Phase 2 sonuçlarına göre yazılıyor, Phase 3 ek katkı.
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| PLN-1 | Option transition graph inşa et — hangi option'dan sonra hangisi başarılı? | 8 | ⬜ |
+| PLN-2 | Lookahead ekle — reactive vs deliberative karşılaştırma | 13 | ⬜ |
+| PLN-3 | Multi-level hierarchy end-to-end: Level-2 meta-controller, iki seviye çalışıyor mu? | 13 | ⬜ |
+
+---
+
+### Phase 4 — Evaluation & Paper (Phase 2 ile Paralel)
+
+| # | Görev | SP | Durum |
+|---|---|---|---|
+| EVAL-1 | W&B dashboard: reconstruction error, option frekansı, per-task reward canlı | 3 | ⬜ |
+| EVAL-2 | BWT / FWT / Average Performance utility — W&B'ye log'layan | 3 | ⬜ |
+| EVAL-3 | Streamlit minimal GUI: aktif sütun, option history, policy görselleştirme | 8 | ⬜ |
+| EVAL-4 | Full evaluation: 3+ görev sırası, tüm metrikler, baseline karşılaştırması | 8 | ⬜ |
+| EVAL-5 | Paper draft — Phase 2 sonuçlarıyla | 13 | ⬜ |
+
+---
+
+## Kritik Path
+
+Bu sıra bloklanırsa sistem bir araya gelemiyor:
+
+```
+PN-1 → PN-2 → PN-3* → PN-4 → OPT-1 → OPT-2 → INT-2
+                ↑
+        Recursive hierarchy tasarım milestone (kağıt üzerinde)
+```
+
+Paralel başlanabilecekler (kritik path'i bloklamıyor):  
+`AE-1, AE-2, GRU-1, GRU-2, EVAL-1, EVAL-2`
+
+---
+
+## Supervisor'a Onaylatılacak Açık Sorular
+
+- [ ] DAG yapısı doğru mu? Aynı primitif sütunlar birden fazla meta-controller tarafından paylaşılabilir mi?
+- [ ] Meta-controller-to-meta-controller recursive option çağrısı ve termination propagation tam olarak nasıl çalışmalı?
+- [ ] Yeni görev yeni katman mı, yeni sütun mu açıyor? Bu kararı ne belirliyor?
+- [ ] GRU continual learning: EWC mi, accumulated data üzerinde retraining mi?
+- [ ] MiniGrid görev sırası onayı: Empty → FourRooms → DoorKey → KeyCorridor → custom multi-key
+- [ ] OPT-1 PoC yaklaşımı onaylandı mı? (frozen PPO policies + meta-controller, PN yok)

--- a/docs/ENS491_Recursive_Hierarchy_Design.md
+++ b/docs/ENS491_Recursive_Hierarchy_Design.md
@@ -1,0 +1,228 @@
+# ENS 491 — Recursive Hierarchy Tasarım Dokümanı
+
+> Bu doküman PN-3'e (mimari-özgün custom PN) başlamadan önce yazılması gereken kağıt tasarımı.  
+> **🔒 Kilitli:** Supervisor onaylı veya tasarım toplantısında netleştirilmiş kararlar.  
+> **⚠️ Açık:** Supervisor onayı bekleniyor veya empirik olarak netleşecek.  
+> **❓ Belirsiz:** Henüz tartışılmadı, ilerleyen aşamada ele alınacak.
+
+---
+
+## 1. Temel Notasyon
+
+**`{n, m}`** — sistemdeki herhangi bir sütunu tanımlar.
+
+- `n` → katman indeksi. `n=0` en alt seviye (primitive skills). `n` arttıkça soyutlama artar.
+- `m` → o katmandaki sütun sırası. `m=1`'den başlar, soldan sağa büyür.
+
+Her iki boyut da **runtime'da büyür** — sistem başlatılırken sabit bir derinlik veya genişlik tanımlanmaz.
+
+```
+Katman n=1:   {1,1}         {1,2}         {1,3}  ...
+               ↑              ↑              ↑
+Katman n=0:  {0,1}  {0,2}  {0,3}  {0,4}  {0,5}  ...
+```
+
+---
+
+## 2. Sütunun Çift Rolü
+
+Her `{n, m}` sütunu **aynı anda** iki şeydir:
+
+1. **Standalone policy** — kendi katmanındaki görev için bağımsız bir PPO politikası.
+2. **Option** — bir üst katmanın meta-controller'ı tarafından çağrılabilecek macro-action.
+
+Bu çift rol mimarinin temelidir. Bir sütun önce policy olarak eğitilir, stabilize olunca bir üst katmana option olarak sunulur.
+
+---
+
+## 3. Hiyerarşi Yapısı
+
+### 3.1 Neden DAG, ağaç değil ⚠️
+
+Aynı primitive sütun (`{0, m}`) birden fazla üst katman meta-controller'ı tarafından paylaşılabilir. Örneğin "kapıya git" becerisi hem DoorKey hem KeyCorridor görevlerinde kullanılıyorsa aynı `{0, m}` sütununa bağlı iki ayrı meta-controller olabilir.
+
+Bu yapı ağaç değil **Directed Acyclic Graph (DAG)**:
+- **Directed:** Bağlantılar her zaman düşük `n`'den yüksek `n`'e (alt katmandan üst katmana).
+- **Acyclic:** Öğrenme tek yönlü — yeni sütunlar eski sütunlara bakabilir, tersi mümkün değil. Acyclic özelliği yapısal olarak garanti altında.
+
+> **⚠️ Supervisor onayı bekleniyor.** DAG varsayımı üzerine tasarım yapılıyor ama kesinleştirilmedi.
+
+### 3.2 Meta-controller'ın görüş alanı 🔒
+
+Her katmandaki meta-controller **yalnızca kendi katmanını** görür:
+- Mevcut ortam gözlemi
+- Kendi katmanındaki mevcut aktif option'ların durumu
+
+Bir üst ya da alt katmanın iç durumuna doğrudan erişimi yoktur.
+
+---
+
+## 4. Lateral Bağlantılar
+
+### 4.1 Tanım 🔒
+
+Lateral bağlantılar **aynı katman içinde, soldan sağa** tanımlıdır:
+
+```
+{n, m-1}  →  {n, m}
+```
+
+`{n, m}` sütunu eğitilirken `{n, m-1}` sütununun ara katman aktivasyonlarına erişebilir. Bu transfer mekanizmasıdır — yeni sütun eski sütundan öğrenir.
+
+### 4.2 Kapsam kısıtlaması 🔒
+
+Lateral bağlantı yalnızca **aynı meta-controller'ın çocukları arasında** geçerlidir. Farklı meta-controller'lara bağlı sütunlar arasında lateral bağlantı yoktur — cross-MC bilgi transferi hiyerarşi seviyesinde, option mekanizmasıyla gerçekleşir.
+
+### 4.3 Inference sırasında lateral bağlantılar ⚠️
+
+Dondurulan `{n, m-1}` sütunu bir üst katmanın option'ı olarak çağrıldığında lateral bağlantıları aktif kalır mı?
+
+**Mevcut tasarım görüşümüz:** Evet — frozen sütun forward pass yapar, aktivasyonları `{n, m}` tarafından okunur. Donma sadece gradient'ı keser, forward pass'ı değil.
+
+> **⚠️ Supervisor onayı bekleniyor.**
+
+---
+
+## 5. Option Wrapping
+
+### 5.1 Bir sütun ne zaman option olur? 🔒
+
+Eğitim ve stabilizasyon sonrasında. "Stabilize" kriteri:
+
+- Reward curve plateau'ya ulaşmış
+- Performans belirli bir eşiğin üzerinde tutarlı
+
+Stabilize olmamış sütun meta-controller'a option olarak sunulmaz.
+
+### 5.2 Option'ın bileşenleri (Sutton et al. 1999)
+
+Her option üç parçadan oluşur:
+
+| Bileşen | İçerik |
+|---|---|
+| **Initiation set** | Option'ın başlatılabileceği state'ler. Şimdilik tüm state uzayı (her yerden çağrılabilir). ❓ Kısıtlanmalı mı? |
+| **Policy** | Sütunun eğitilmiş PPO politikası. Frozen. |
+| **Termination condition** | Ne zaman durulacak. ⚠️ Bakınız Bölüm 6. |
+
+---
+
+## 6. Termination ve Recursive Çağrı
+
+### 6.1 Tek seviye çağrı
+
+```
+Meta-controller (n=1)  →  option {0, m} çağır
+{0, m} çalışır
+{0, m} terminates
+Meta-controller (n=1) kontrolü geri alır
+```
+
+### 6.2 Recursive çağrı ⚠️
+
+```
+Meta-controller (n=2)  →  option {1, k} çağır
+{1, k} kendi içinde meta-controller gibi davranır
+{1, k}  →  option {0, m} çağır
+{0, m} terminates → {1, k}'ya sinyal
+{1, k} terminates → MC(n=2)'ye sinyal
+MC(n=2) kontrolü geri alır
+```
+
+Termination **aşağıdan yukarıya propagate eder.** Her seviye kendi termination kararını verir, bir üst seviyeyi bilgilendirir.
+
+**Termination alternatifleri (empirik karşılaştırılacak):**
+
+| Strateji | Mekanizma | Risk |
+|---|---|---|
+| Sabit adım limiti | Option en fazla K adım çalışır | K'nın göreve göre ayarlanması gerekiyor |
+| Öğrenilen termination | Option-Critic tarzı — termination ağı karar verir | Eğitim instabilitesi |
+| GRU task-change sinyali | GRU yeni görev algılayınca mevcut option'ı sonlandır | Modüller arası bağımlılık artar |
+
+> **⚠️ Recursive termination propagation'ın tam mekaniği supervisor toplantısında netleştirilecek.**
+
+---
+
+## 7. Runtime Growth: Yeni Sütun mu, Yeni Katman mı?
+
+### 7.1 Yeni sütun açma (mevcut katmanda genişleme)
+
+Tetik: AE reconstruction error threshold'u aşıldı **ve/veya** mevcut policy reward plateau'da.
+
+```
+{n, m} → sistem yeni görevi algılar → {n, m+1} sütun açılır → eğitilir → stabilize → option'a eklenir
+```
+
+### 7.2 Yeni katman açma (hiyerarşi derinleşiyor)
+
+Tetik: Mevcut görev, mevcut katmandaki primitive option'ların **kombinasyonunu** gerektiriyor.
+
+**Mevcut görüş:** Bu "category detection" problemi — hangi sinyalin yeni katman açacağını belirlemek açık bir araştırma sorusudur. Düşünülen yaklaşımlar:
+
+- Mevcut katmanın meta-controller'ı option'lar arası geçişi çok sık yapıyorsa (yüksek switching) → soyutlama eksik → yeni katman
+- Reward decomposition: alt katman ödüllendirilip üst katman ödüllendirilmiyorsa → ara soyutlama gerekiyor
+- World model tabanlı karar (Phase 3 / scope dışı şimdilik)
+
+> **⚠️ Supervisor toplantısında tartışılacak.** Şimdilik yeni katman açma kararı manuel / explicit olacak — Phase 1-2 boyunca yeni katman açılmayacak, Phase 3'te ele alınacak.
+
+---
+
+## 8. Inference Akışı — Uçtan Uca
+
+Sistemin bir adımı şöyle işler:
+
+```
+1. Ortamdan gözlem al: obs_t
+
+2. AE: reconstruction_error(obs_t)
+   - Yüksekse → yeni görev → yeni sütun süreci başlat
+   - Düşükse → adım 3'e geç
+
+3. GRU: task_id = classify(obs_{t-N:t})
+   - Hangi görevdeyiz?
+
+4. Meta-controller (en üst aktif katman):
+   - State: obs_t + task context
+   - Çıktı: hangi option çağırılacak
+
+5. Seçilen option çalışır:
+   - Kendi içinde recursive olarak aynı akışı yapabilir
+   - Termination condition sağlanınca durur
+
+6. Reward, meta-controller'a döner
+   - Alt katmandaki reward sinyali ile meta-controller reward sinyali AYRI tutulur
+   - Merge edilmez
+```
+
+---
+
+## 9. Implementasyon Gereksinimleri (PN-3 için)
+
+Bu tasarımı kodlamak için `Column` sınıfının şu özellikleri taşıması gerekiyor:
+
+```python
+class Column:
+    n: int                    # katman indeksi
+    m: int                    # sütun sırası
+    policy: PPOPolicy         # eğitilmiş politika
+    frozen: bool              # True ise gradient yok
+    lateral_source: Column | None  # {n, m-1} referansı
+    is_option: bool           # meta-controller'a sunuldu mu?
+    sub_layer: MetaController | None  # None ise leaf (n=0)
+```
+
+`sub_layer = None` → primitive column (leaf node)  
+`sub_layer = MetaController(...)` → bu sütun hem policy hem üst meta-controller
+
+Bu yapı recursive tanım — sütun kendi içinde bir alt meta-controller barındırabilir. Baştan böyle tasarlanmazsa PN-3 sonrasında rewrite gerekir.
+
+---
+
+## 10. Açık Sorular — Supervisor Toplantısı Gündemi
+
+| # | Soru | Neden kritik |
+|---|---|---|
+| H-1 | DAG yapısı doğru mu? Aynı primitive sütun birden fazla MC'ye bağlanabilir mi? | Tüm mimari buna göre şekilleniyor |
+| H-2 | Recursive MC→MC option çağrısında termination propagation tam olarak nasıl? | PN-3 implementasyonu bunu varsayıyor |
+| H-3 | Lateral bağlantılar frozen sütun inference sırasında aktif kalıyor mu? | Forward pass davranışı değişir |
+| H-4 | Yeni katman açma sinyali ne olacak? Manuel mi, otomatik mi? | Phase 2 scope'unu belirliyor |
+| H-5 | Option initiation set kısıtlanacak mı, yoksa everywhere başlatılabilir mi? | Meta-controller exploration'ını etkiliyor |

--- a/docs/ENS491_Recursive_Hierarchy_Design.md
+++ b/docs/ENS491_Recursive_Hierarchy_Design.md
@@ -1,228 +1,227 @@
-# ENS 491 — Recursive Hierarchy Tasarım Dokümanı
+# ENS 491 — Recursive Hierarchy Design
 
-> Bu doküman PN-3'e (mimari-özgün custom PN) başlamadan önce yazılması gereken kağıt tasarımı.  
-> **🔒 Kilitli:** Supervisor onaylı veya tasarım toplantısında netleştirilmiş kararlar.  
-> **⚠️ Açık:** Supervisor onayı bekleniyor veya empirik olarak netleşecek.  
-> **❓ Belirsiz:** Henüz tartışılmadı, ilerleyen aşamada ele alınacak.
+> This document is the paper design required before starting PN-3 (architecture-specific custom PN).  
+> **🔒 Locked:** Decided and agreed upon — not open for debate.  
+> **⚠️ Open:** Pending supervisor confirmation or empirical resolution.  
+> **❓ Unclear:** Not yet discussed, to be addressed in a later phase.
 
 ---
 
-## 1. Temel Notasyon
+## 1. Notation
 
-**`{n, m}`** — sistemdeki herhangi bir sütunu tanımlar.
+**`{n, m}`** — identifies any column in the system.
 
-- `n` → katman indeksi. `n=0` en alt seviye (primitive skills). `n` arttıkça soyutlama artar.
-- `m` → o katmandaki sütun sırası. `m=1`'den başlar, soldan sağa büyür.
+- `n` → layer index. `n=0` is the lowest level (primitive skills). Higher `n` = higher abstraction.
+- `m` → column position within the layer. Starts at `m=1`, grows left to right.
 
-Her iki boyut da **runtime'da büyür** — sistem başlatılırken sabit bir derinlik veya genişlik tanımlanmaz.
+Both dimensions **grow at runtime** — no fixed depth or width is defined at startup.
 
 ```
-Katman n=1:   {1,1}         {1,2}         {1,3}  ...
+Layer n=1:   {1,1}         {1,2}         {1,3}  ...
                ↑              ↑              ↑
-Katman n=0:  {0,1}  {0,2}  {0,3}  {0,4}  {0,5}  ...
+Layer n=0:  {0,1}  {0,2}  {0,3}  {0,4}  {0,5}  ...
 ```
 
 ---
 
-## 2. Sütunun Çift Rolü
+## 2. The Dual Role of a Column
 
-Her `{n, m}` sütunu **aynı anda** iki şeydir:
+Every `{n, m}` column is **simultaneously** two things:
 
-1. **Standalone policy** — kendi katmanındaki görev için bağımsız bir PPO politikası.
-2. **Option** — bir üst katmanın meta-controller'ı tarafından çağrılabilecek macro-action.
+1. **Standalone policy** — an independent PPO policy for its task at its layer.
+2. **Option** — a macro-action that can be called by the meta-controller of the layer above.
 
-Bu çift rol mimarinin temelidir. Bir sütun önce policy olarak eğitilir, stabilize olunca bir üst katmana option olarak sunulur.
-
----
-
-## 3. Hiyerarşi Yapısı
-
-### 3.1 Neden DAG, ağaç değil ⚠️
-
-Aynı primitive sütun (`{0, m}`) birden fazla üst katman meta-controller'ı tarafından paylaşılabilir. Örneğin "kapıya git" becerisi hem DoorKey hem KeyCorridor görevlerinde kullanılıyorsa aynı `{0, m}` sütununa bağlı iki ayrı meta-controller olabilir.
-
-Bu yapı ağaç değil **Directed Acyclic Graph (DAG)**:
-- **Directed:** Bağlantılar her zaman düşük `n`'den yüksek `n`'e (alt katmandan üst katmana).
-- **Acyclic:** Öğrenme tek yönlü — yeni sütunlar eski sütunlara bakabilir, tersi mümkün değil. Acyclic özelliği yapısal olarak garanti altında.
-
-> **⚠️ Supervisor onayı bekleniyor.** DAG varsayımı üzerine tasarım yapılıyor ama kesinleştirilmedi.
-
-### 3.2 Meta-controller'ın görüş alanı 🔒
-
-Her katmandaki meta-controller **yalnızca kendi katmanını** görür:
-- Mevcut ortam gözlemi
-- Kendi katmanındaki mevcut aktif option'ların durumu
-
-Bir üst ya da alt katmanın iç durumuna doğrudan erişimi yoktur.
+This dual role is fundamental to the architecture. A column is first trained as a policy, then once stabilized it is offered as an option to the layer above.
 
 ---
 
-## 4. Lateral Bağlantılar
+## 3. Hierarchy Structure
 
-### 4.1 Tanım 🔒
+### 3.1 Tree structure 🔒
 
-Lateral bağlantılar **aynı katman içinde, soldan sağa** tanımlıdır:
+The hierarchy is implemented as a **tree**. Each primitive column belongs to exactly one meta-controller.
+
+```
+MC(n=1)
+├── {0,1}
+├── {0,2}
+└── {0,3}
+```
+
+**Why tree, not DAG:**
+- At the scale of Phase 1-2 (2-4 tasks, single MC layer) there are no primitive columns to share — DAG provides zero benefit at this scale.
+- Python object references naturally allow DAG if needed later. Implementing as tree does not prevent DAG; we are simply not enforcing it now.
+- Avoids unnecessary complexity.
+
+Connections always flow from lower `n` to higher `n` — learning is one-directional, acyclic property is structurally guaranteed.
+
+### 3.2 Meta-controller scope 🔒
+
+Each meta-controller **only sees its own layer**:
+- Current environment observation
+- Status of options currently available at its layer
+
+It has no direct access to the internal state of layers above or below.
+
+---
+
+## 4. Lateral Connections
+
+### 4.1 Definition 🔒
+
+Lateral connections are defined **within a layer, left to right**:
 
 ```
 {n, m-1}  →  {n, m}
 ```
 
-`{n, m}` sütunu eğitilirken `{n, m-1}` sütununun ara katman aktivasyonlarına erişebilir. Bu transfer mekanizmasıdır — yeni sütun eski sütundan öğrenir.
+While `{n, m}` is being trained, it can access the intermediate layer activations of `{n, m-1}`. This is the transfer mechanism — the new column learns from the old one.
 
-### 4.2 Kapsam kısıtlaması 🔒
+### 4.2 Scope constraint 🔒
 
-Lateral bağlantı yalnızca **aynı meta-controller'ın çocukları arasında** geçerlidir. Farklı meta-controller'lara bağlı sütunlar arasında lateral bağlantı yoktur — cross-MC bilgi transferi hiyerarşi seviyesinde, option mekanizmasıyla gerçekleşir.
+Lateral connections only exist **between columns managed by the same meta-controller**. There are no lateral connections between columns belonging to different meta-controllers — cross-MC knowledge transfer happens at the hierarchy level, via the option mechanism.
 
-### 4.3 Inference sırasında lateral bağlantılar ⚠️
+### 4.3 Lateral connections during inference ⚠️
 
-Dondurulan `{n, m-1}` sütunu bir üst katmanın option'ı olarak çağrıldığında lateral bağlantıları aktif kalır mı?
+When a frozen `{n, m-1}` column is called as an option by an upper layer, do its lateral connections remain active?
 
-**Mevcut tasarım görüşümüz:** Evet — frozen sütun forward pass yapar, aktivasyonları `{n, m}` tarafından okunur. Donma sadece gradient'ı keser, forward pass'ı değil.
+**Current design position:** Yes — the frozen column runs a forward pass and its activations are read by `{n, m}`. Freezing only blocks gradients, not the forward pass.
 
-> **⚠️ Supervisor onayı bekleniyor.**
+> **⚠️ Pending supervisor confirmation.**
 
 ---
 
 ## 5. Option Wrapping
 
-### 5.1 Bir sütun ne zaman option olur? 🔒
+### 5.1 When does a column become an option? 🔒
 
-Eğitim ve stabilizasyon sonrasında. "Stabilize" kriteri:
+After training and stabilization. "Stabilized" means:
 
-- Reward curve plateau'ya ulaşmış
-- Performans belirli bir eşiğin üzerinde tutarlı
+- Reward curve has reached a plateau
+- Performance is consistently above a defined threshold
 
-Stabilize olmamış sütun meta-controller'a option olarak sunulmaz.
+An unstabilized column is never added to a MetaController as an option.
 
-### 5.2 Option'ın bileşenleri (Sutton et al. 1999)
+### 5.2 Option components (Sutton et al. 1999)
 
-Her option üç parçadan oluşur:
-
-| Bileşen | İçerik |
+| Component | Content |
 |---|---|
-| **Initiation set** | Option'ın başlatılabileceği state'ler. Şimdilik tüm state uzayı (her yerden çağrılabilir). ❓ Kısıtlanmalı mı? |
-| **Policy** | Sütunun eğitilmiş PPO politikası. Frozen. |
-| **Termination condition** | Ne zaman durulacak. ⚠️ Bakınız Bölüm 6. |
+| **Initiation set** | States from which the option can be started. Currently the full state space (callable from anywhere). ❓ Should this be restricted? |
+| **Policy** | The column's trained PPO policy. Frozen. |
+| **Termination condition** | When to stop. ⚠️ See Section 6. |
 
 ---
 
-## 6. Termination ve Recursive Çağrı
+## 6. Termination and Recursive Calling
 
-### 6.1 Tek seviye çağrı
+### 6.1 Single-level call
 
 ```
-Meta-controller (n=1)  →  option {0, m} çağır
-{0, m} çalışır
+MetaController (n=1)  →  calls option {0, m}
+{0, m} runs
 {0, m} terminates
-Meta-controller (n=1) kontrolü geri alır
+MetaController (n=1) regains control
 ```
 
-### 6.2 Recursive çağrı ⚠️
+### 6.2 Recursive call ⚠️
 
 ```
-Meta-controller (n=2)  →  option {1, k} çağır
-{1, k} kendi içinde meta-controller gibi davranır
-{1, k}  →  option {0, m} çağır
-{0, m} terminates → {1, k}'ya sinyal
-{1, k} terminates → MC(n=2)'ye sinyal
-MC(n=2) kontrolü geri alır
+MetaController (n=2)  →  calls option {1, k}
+{1, k} acts as a meta-controller internally
+{1, k}  →  calls option {0, m}
+{0, m} terminates → signals {1, k}
+{1, k} terminates → signals MC(n=2)
+MC(n=2) regains control
 ```
 
-Termination **aşağıdan yukarıya propagate eder.** Her seviye kendi termination kararını verir, bir üst seviyeyi bilgilendirir.
+Termination **propagates bottom-up.** Each level makes its own termination decision and signals the level above.
 
-**Termination alternatifleri (empirik karşılaştırılacak):**
+**Termination strategies (to be compared empirically):**
 
-| Strateji | Mekanizma | Risk |
+| Strategy | Mechanism | Risk |
 |---|---|---|
-| Sabit adım limiti | Option en fazla K adım çalışır | K'nın göreve göre ayarlanması gerekiyor |
-| Öğrenilen termination | Option-Critic tarzı — termination ağı karar verir | Eğitim instabilitesi |
-| GRU task-change sinyali | GRU yeni görev algılayınca mevcut option'ı sonlandır | Modüller arası bağımlılık artar |
+| Fixed step limit | Option runs for at most K steps | K needs to be tuned per task |
+| Learned termination | Option-Critic style — termination network decides | Training instability |
+| GRU task-change signal | Terminate current option when GRU detects task switch | Increases inter-module coupling |
 
-> **⚠️ Recursive termination propagation'ın tam mekaniği supervisor toplantısında netleştirilecek.**
-
----
-
-## 7. Runtime Growth: Yeni Sütun mu, Yeni Katman mı?
-
-### 7.1 Yeni sütun açma (mevcut katmanda genişleme)
-
-Tetik: AE reconstruction error threshold'u aşıldı **ve/veya** mevcut policy reward plateau'da.
-
-```
-{n, m} → sistem yeni görevi algılar → {n, m+1} sütun açılır → eğitilir → stabilize → option'a eklenir
-```
-
-### 7.2 Yeni katman açma (hiyerarşi derinleşiyor)
-
-Tetik: Mevcut görev, mevcut katmandaki primitive option'ların **kombinasyonunu** gerektiriyor.
-
-**Mevcut görüş:** Bu "category detection" problemi — hangi sinyalin yeni katman açacağını belirlemek açık bir araştırma sorusudur. Düşünülen yaklaşımlar:
-
-- Mevcut katmanın meta-controller'ı option'lar arası geçişi çok sık yapıyorsa (yüksek switching) → soyutlama eksik → yeni katman
-- Reward decomposition: alt katman ödüllendirilip üst katman ödüllendirilmiyorsa → ara soyutlama gerekiyor
-- World model tabanlı karar (Phase 3 / scope dışı şimdilik)
-
-> **⚠️ Supervisor toplantısında tartışılacak.** Şimdilik yeni katman açma kararı manuel / explicit olacak — Phase 1-2 boyunca yeni katman açılmayacak, Phase 3'te ele alınacak.
+> **⚠️ Exact mechanics of recursive termination propagation to be confirmed with supervisor.**
 
 ---
 
-## 8. Inference Akışı — Uçtan Uca
+## 7. Runtime Growth: New Column vs New Layer
 
-Sistemin bir adımı şöyle işler:
+### 7.1 Opening a new column (expanding within current layer)
+
+Trigger: AE reconstruction error exceeds threshold **and/or** current policy reward has plateaued.
 
 ```
-1. Ortamdan gözlem al: obs_t
+{n, m} → system detects new task → {n, m+1} opens → trains → stabilizes → added as option
+```
+
+### 7.2 Opening a new layer (hierarchy deepens)
+
+Trigger: Current task requires a **combination** of primitive options from the current layer.
+
+**Current position:** This is the "category detection" problem — determining which signal should open a new layer is an open research question. New layer decisions will be **manual/explicit** throughout Phase 1-2. Addressed in Phase 3.
+
+> **⚠️ To be discussed with supervisor.**
+
+---
+
+## 8. End-to-End Inference Flow
+
+```
+1. Receive observation: obs_t
 
 2. AE: reconstruction_error(obs_t)
-   - Yüksekse → yeni görev → yeni sütun süreci başlat
-   - Düşükse → adım 3'e geç
+   - High → new task → start new column process
+   - Low  → proceed to step 3
 
 3. GRU: task_id = classify(obs_{t-N:t})
-   - Hangi görevdeyiz?
+   - Which task are we in?
 
-4. Meta-controller (en üst aktif katman):
-   - State: obs_t + task context
-   - Çıktı: hangi option çağırılacak
+4. MetaController (topmost active layer):
+   - Input: obs_t + task context
+   - Output: which option to call
 
-5. Seçilen option çalışır:
-   - Kendi içinde recursive olarak aynı akışı yapabilir
-   - Termination condition sağlanınca durur
+5. Selected option runs:
+   - Can recursively run the same flow internally
+   - Stops when termination condition is met
 
-6. Reward, meta-controller'a döner
-   - Alt katmandaki reward sinyali ile meta-controller reward sinyali AYRI tutulur
-   - Merge edilmez
+6. Reward returned to MetaController
+   - Sub-layer reward signal and MetaController reward signal kept SEPARATE
+   - Never merged
 ```
 
 ---
 
-## 9. Implementasyon Gereksinimleri (PN-3 için)
+## 9. Implementation Requirements (for PN-3)
 
-Bu tasarımı kodlamak için `Column` sınıfının şu özellikleri taşıması gerekiyor:
+The `Column` class must carry the following fields to implement this design:
 
 ```python
 class Column:
-    n: int                    # katman indeksi
-    m: int                    # sütun sırası
-    policy: PPOPolicy         # eğitilmiş politika
-    frozen: bool              # True ise gradient yok
-    lateral_source: Column | None  # {n, m-1} referansı
-    is_option: bool           # meta-controller'a sunuldu mu?
-    sub_layer: MetaController | None  # None ise leaf (n=0)
+    n: int                              # layer index
+    m: int                              # column position
+    policy: PPOPolicy                   # trained policy
+    frozen: bool                        # True = no gradient
+    lateral_source: Column | None       # ref to {n, m-1}
+    is_option: bool                     # has been added to MetaController?
+    sub_layer: MetaController | None    # None = leaf (n=0)
 ```
 
 `sub_layer = None` → primitive column (leaf node)  
-`sub_layer = MetaController(...)` → bu sütun hem policy hem üst meta-controller
+`sub_layer = MetaController(...)` → this column is both a policy and a hierarchy manager
 
-Bu yapı recursive tanım — sütun kendi içinde bir alt meta-controller barındırabilir. Baştan böyle tasarlanmazsa PN-3 sonrasında rewrite gerekir.
+This is a recursive definition — a column can contain a sub-MetaController, which manages more columns. If this is not designed in from the start, PN-3 will require a rewrite later.
 
 ---
 
-## 10. Açık Sorular — Supervisor Toplantısı Gündemi
+## 10. Open Questions — Supervisor Meeting Agenda
 
-| # | Soru | Neden kritik |
+| # | Question | Why it matters |
 |---|---|---|
-| H-1 | DAG yapısı doğru mu? Aynı primitive sütun birden fazla MC'ye bağlanabilir mi? | Tüm mimari buna göre şekilleniyor |
-| H-2 | Recursive MC→MC option çağrısında termination propagation tam olarak nasıl? | PN-3 implementasyonu bunu varsayıyor |
-| H-3 | Lateral bağlantılar frozen sütun inference sırasında aktif kalıyor mu? | Forward pass davranışı değişir |
-| H-4 | Yeni katman açma sinyali ne olacak? Manuel mi, otomatik mi? | Phase 2 scope'unu belirliyor |
-| H-5 | Option initiation set kısıtlanacak mı, yoksa everywhere başlatılabilir mi? | Meta-controller exploration'ını etkiliyor |
+| H-2 | How exactly does termination propagation work in recursive MC→MC option calls? | PN-3 implementation depends on this |
+| H-3 | Do lateral connections remain active when a frozen column is used as an option during inference? | Changes forward pass behavior |
+| H-4 | What signal triggers a new layer? Manual or automatic? | Determines Phase 2 scope |
+| H-5 | Should the option initiation set be restricted, or is everywhere-initiation acceptable? | Affects MetaController exploration |

--- a/docs/SUPERVISOR_QUESTIONS.md
+++ b/docs/SUPERVISOR_QUESTIONS.md
@@ -1,0 +1,14 @@
+# Supervisor Meeting — Open Questions
+
+> This file is a meeting agenda, not implementation guidance.  
+> Claude Code does not need to read this file.
+
+---
+
+- [ ] How exactly does termination propagation work in recursive MC→MC option calls?
+- [ ] Do lateral connections remain active when a frozen column is used as an option during inference?
+- [ ] Does a new task open a new layer or a new column? What determines this?
+- [ ] GRU continual learning: EWC or retraining on accumulated data?
+- [ ] Task sequence approval: Empty → FourRooms → DoorKey → KeyCorridor → custom multi-key
+- [ ] Is the OPT-1 PoC approach approved? (frozen PPO policies + meta-controller, no PN)
+- [ ] Should the option initiation set be restricted, or is everywhere-initiation acceptable?

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch>=2.0.0
+stable-baselines3>=2.0.0
+minigrid>=2.3.0
+gymnasium>=0.29.0
+streamlit>=1.28.0
+numpy>=1.24.0

--- a/src/continual_learning/__init__.py
+++ b/src/continual_learning/__init__.py
@@ -1,0 +1,7 @@
+from src.continual_learning.column import Column
+from src.continual_learning.stabilization import StabilizationMonitor
+
+__all__ = ["Column", "StabilizationMonitor"]
+# ColumnPolicy, LateralMlpExtractor, ColumnTrainer require SB3 — import directly:
+#   from src.continual_learning.column_policy import ColumnPolicy, LateralMlpExtractor
+#   from src.continual_learning.pn_trainer import ColumnTrainer

--- a/src/continual_learning/column.py
+++ b/src/continual_learning/column.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+import numpy as np
+import torch
+
+from src.types import Action, ColumnOutput, LayerIdx, ColumnIdx, Observation
+
+if TYPE_CHECKING:
+    from src.continual_learning.column_policy import ColumnPolicy
+
+
+def _to_tensor(obs: Observation | np.ndarray) -> torch.Tensor:
+    if isinstance(obs, torch.Tensor):
+        return obs.float()
+    return torch.tensor(obs, dtype=torch.float32)
+
+
+class Column:
+    """
+    A single Progressive Network column: policy + lateral receiver + hierarchy slot.
+
+    Coordinates use 1-indexed m (e.g. {0,1} is the first primitive column).
+
+    sub_layer: always None in Phase 1. Set to a MetaController in Phase 2 to
+    make this column a non-leaf node in the recursive hierarchy.
+    """
+
+    def __init__(
+        self,
+        n: LayerIdx,
+        m: ColumnIdx,
+        lateral_source: Optional[Column] = None,
+        sub_layer=None,
+    ) -> None:
+        self.n = n
+        self.m = m  # 1-indexed
+        self.frozen = False
+        self.lateral_source = lateral_source
+        self.sub_layer = sub_layer  # None = leaf (Phase 1); MetaController in Phase 2
+        self.policy: Optional[ColumnPolicy] = None  # set by ColumnTrainer after training
+
+    # ------------------------------------------------------------------
+    # Core interface
+    # ------------------------------------------------------------------
+
+    def forward(self, obs: Observation | np.ndarray) -> ColumnOutput:
+        if self.policy is None:
+            raise RuntimeError(
+                f"Column {{{self.n},{self.m}}}: policy is None. "
+                "Call ColumnTrainer.train() or attach a policy before calling forward()."
+            )
+        obs_t = _to_tensor(obs)
+        obs_np = obs_t.cpu().numpy()
+
+        action, _ = self.policy.predict(obs_np, deterministic=not self.frozen)
+        action = int(action)
+
+        params = list(self.policy.parameters())
+        device = params[0].device if params else torch.device("cpu")
+        obs_tensor = obs_t.unsqueeze(0).to(device)  # match policy device
+        with torch.no_grad():
+            value = self.policy.predict_values(obs_tensor).item()
+
+        activations = self.policy.mlp_extractor.get_activations()
+        return ColumnOutput(action=action, value=value, activations=dict(activations))
+
+    def freeze(self) -> None:
+        """Freeze all policy weights. Forward pass still runs for lateral connections."""
+        if self.policy is None:
+            raise RuntimeError(f"Column {{{self.n},{self.m}}}: cannot freeze — policy is None.")
+        self.frozen = True
+        for p in self.policy.parameters():
+            p.requires_grad_(False)
+
+    def get_activations(self) -> dict[int, torch.Tensor]:
+        """Return intermediate activations from the last forward pass."""
+        if self.policy is None:
+            return {}
+        return self.policy.mlp_extractor.get_activations()
+
+    def as_option(self) -> object:
+        """Wrap this column as an Option (import deferred to avoid circular import)."""
+        from src.options.option import Option
+        return Option(column=self, option_id=(self.n, self.m))
+
+    def __repr__(self) -> str:
+        status = "frozen" if self.frozen else "active"
+        lateral = f"←{{{self.lateral_source.n},{self.lateral_source.m}}}" if self.lateral_source else ""
+        return f"Column({{{self.n},{self.m}}} {status}{lateral})"

--- a/src/continual_learning/column_policy.py
+++ b/src/continual_learning/column_policy.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from stable_baselines3.common.policies import ActorCriticPolicy
+
+if TYPE_CHECKING:
+    from src.continual_learning.column import Column
+
+
+class LateralMlpExtractor(nn.Module):
+    """
+    Two-hidden-layer MLP feature extractor with optional lateral connections.
+
+    Architecture: obs(147) → fc1(64) → fc2(64)
+    Lateral: a linear projection from each of the source's hidden layers is
+    added element-wise before the ReLU activation.
+
+    SB3 2.x contract: must expose forward(), forward_actor(), forward_critic().
+    - forward(features) → (pi_features, vf_features)  [called during PPO update]
+    - forward_actor(features) → pi_features            [called during predict / get_distribution]
+    - forward_critic(features) → vf_features           [called during predict_values]
+
+    Lateral re-computation: during SB3's batched PPO update, forward_actor() re-runs
+    the frozen source on the same features batch under torch.no_grad(). This ensures
+    activations are correct for the training batch, not stale inference activations.
+    """
+
+    def __init__(self, feature_dim: int, lateral_source_column: Optional[Column] = None) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(feature_dim, 64)
+        self.fc2 = nn.Linear(64, 64)
+
+        self.lateral_source_column = lateral_source_column
+        if lateral_source_column is not None:
+            self.lat1 = nn.Linear(64, 64, bias=False)
+            self.lat2 = nn.Linear(64, 64, bias=False)
+
+        # SB3 contract
+        self.latent_dim_pi = 64
+        self.latent_dim_vf = 64
+
+        self._acts: dict[int, torch.Tensor] = {}
+
+    def _extract(self, features: torch.Tensor) -> torch.Tensor:
+        """Core MLP + lateral computation. Stores activations; returns h2."""
+        features = features.to(self.fc1.weight.device)
+        lat_acts: dict[int, torch.Tensor] = {}
+        if self.lateral_source_column is not None:
+            # Re-run frozen source on this batch to get matching activations.
+            # Source has requires_grad_(False) so no gradient flows into it.
+            with torch.no_grad():
+                self.lateral_source_column.policy.mlp_extractor._extract(features)
+            lat_acts = self.lateral_source_column.policy.mlp_extractor._acts
+
+        h1 = F.relu(self.fc1(features))
+        if lat_acts and 0 in lat_acts:
+            h1 = h1 + self.lat1(lat_acts[0])
+        self._acts[0] = h1.detach()
+
+        h2 = F.relu(self.fc2(h1))
+        if lat_acts and 1 in lat_acts:
+            h2 = h2 + self.lat2(lat_acts[1])
+        self._acts[1] = h2.detach()
+
+        return h2
+
+    def forward(self, features: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """SB3 2.x: called during PPO evaluate_actions(). Returns (pi, vf)."""
+        h = self._extract(features)
+        return h, h
+
+    def forward_actor(self, features: torch.Tensor) -> torch.Tensor:
+        """SB3 2.x: called during predict() / get_distribution()."""
+        return self._extract(features)
+
+    def forward_critic(self, features: torch.Tensor) -> torch.Tensor:
+        """SB3 2.x: called during predict_values()."""
+        return self._extract(features)
+
+    def get_activations(self) -> dict[int, torch.Tensor]:
+        return self._acts
+
+
+class ColumnPolicy(ActorCriticPolicy):
+    """
+    SB3 ActorCriticPolicy backed by LateralMlpExtractor.
+
+    Pass lateral_source_column via policy_kwargs:
+        PPO(ColumnPolicy, env, policy_kwargs={"lateral_source_column": col})
+    """
+
+    def __init__(self, *args, lateral_source_column: Optional[Column] = None, **kwargs) -> None:
+        self._lateral_source_column = lateral_source_column
+        super().__init__(*args, **kwargs)
+
+    def _build_mlp_extractor(self) -> None:
+        self.mlp_extractor = LateralMlpExtractor(
+            feature_dim=self.features_dim,
+            lateral_source_column=self._lateral_source_column,
+        )

--- a/src/continual_learning/pn_trainer.py
+++ b/src/continual_learning/pn_trainer.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import gymnasium as gym
+import minigrid  # noqa: F401 — registers MiniGrid envs
+from gymnasium.wrappers import FlattenObservation
+from minigrid.wrappers import ImgObsWrapper
+from stable_baselines3 import PPO
+from stable_baselines3.common.callbacks import BaseCallback
+
+from src.continual_learning.column import Column
+from src.continual_learning.column_policy import ColumnPolicy
+from src.continual_learning.stabilization import StabilizationMonitor
+
+
+class _EpisodeRewardCallback(BaseCallback):
+    """Feeds episode rewards into a StabilizationMonitor after each episode ends."""
+
+    def __init__(self, monitor: StabilizationMonitor) -> None:
+        super().__init__()
+        self._monitor = monitor
+
+    def _on_step(self) -> bool:
+        for info in self.locals.get("infos", []):
+            ep = info.get("episode")
+            if ep is not None:
+                self._monitor.update(ep["r"])
+        return True
+
+
+class ColumnTrainer:
+    """
+    Trains a single Column using SB3 PPO with ColumnPolicy (with optional laterals).
+
+    After training, the trained policy is attached to column.policy so that
+    column.forward() works and column.freeze() can be called.
+    """
+
+    def __init__(
+        self,
+        column: Column,
+        env_id: str,
+        total_timesteps: int = 100_000,
+        verbose: int = 0,
+    ) -> None:
+        self.column = column
+        self.env_id = env_id
+        self.total_timesteps = total_timesteps
+        self.verbose = verbose
+        self._monitor = StabilizationMonitor()
+
+    def _make_env(self) -> gym.Env:
+        # ImgObsWrapper extracts the 7×7×3 image; FlattenObservation gives (147,) uint8 obs.
+        # This matches the obs_dim=147 used throughout the codebase.
+        env = gym.make(self.env_id)
+        return FlattenObservation(ImgObsWrapper(env))
+
+    def train(self) -> None:
+        env = self._make_env()
+        policy_kwargs = {"lateral_source_column": self.column.lateral_source}
+        model = PPO(
+            ColumnPolicy,
+            env,
+            policy_kwargs=policy_kwargs,
+            verbose=self.verbose,
+        )
+        callback = _EpisodeRewardCallback(self._monitor)
+        model.learn(total_timesteps=self.total_timesteps, callback=callback)
+        self.column.policy = model.policy
+        env.close()
+
+    def is_stable(self) -> bool:
+        return self._monitor.is_stable()
+
+    @property
+    def monitor(self) -> StabilizationMonitor:
+        return self._monitor

--- a/src/continual_learning/stabilization.py
+++ b/src/continual_learning/stabilization.py
@@ -1,0 +1,36 @@
+from collections import deque
+import statistics
+
+
+class StabilizationMonitor:
+    """Tracks episode rewards and signals when a column has stabilised."""
+
+    WINDOW = 50
+    REWARD_THRESHOLD = 0.85
+    STD_THRESHOLD = 0.05
+
+    def __init__(self) -> None:
+        self._rewards: deque[float] = deque(maxlen=self.WINDOW)
+
+    def update(self, episode_reward: float) -> None:
+        self._rewards.append(episode_reward)
+
+    def is_stable(self) -> bool:
+        if len(self._rewards) < self.WINDOW:
+            return False
+        mean = statistics.mean(self._rewards)
+        std = statistics.stdev(self._rewards)
+        return mean >= self.REWARD_THRESHOLD and std <= self.STD_THRESHOLD
+
+    def reset(self) -> None:
+        self._rewards.clear()
+
+    @property
+    def mean_reward(self) -> float:
+        if not self._rewards:
+            return 0.0
+        return statistics.mean(self._rewards)
+
+    @property
+    def n_episodes(self) -> int:
+        return len(self._rewards)

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -1,0 +1,266 @@
+"""
+Minimal Streamlit GUI — ENS491 Progress Report I
+
+Architectural flow display:
+  - AE reconstruction error + novelty decision
+  - GRU predicted task + confidence + probability bars
+  - Column hierarchy (n, m, frozen, lateral connection)
+  - Option selection history
+  - Current action / reward (live mode only)
+
+Modes:
+  Demo mode (default): loads runs/demo_state.pkl as a plain dict of metrics.
+  Live mode (sidebar toggle): imports TaskLifecycleManager and polls get_state().
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import random
+import time
+from pathlib import Path
+from typing import Optional
+
+import streamlit as st
+
+# ---------------------------------------------------------------------------
+# Page config
+# ---------------------------------------------------------------------------
+st.set_page_config(
+    page_title="ENS491 — Hierarchical CRL Agent",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+DEMO_STATE_PATH = Path(__file__).parent.parent.parent / "runs" / "demo_state.pkl"
+
+# ---------------------------------------------------------------------------
+# Demo state loader
+# ---------------------------------------------------------------------------
+
+def _load_demo_state() -> dict:
+    """Load plain-dict demo state. Returns a minimal default if file is missing."""
+    if DEMO_STATE_PATH.exists():
+        with open(DEMO_STATE_PATH, "rb") as f:
+            return pickle.load(f)
+    # Minimal default for first launch
+    return {
+        "ae_error": 0.031,
+        "ae_threshold": 0.05,
+        "is_novel": False,
+        "gru_task_id": 0,
+        "gru_confidence": 0.83,
+        "gru_all_probs": [0.83, 0.17],
+        "columns": [
+            {"n": 0, "m": 1, "frozen": True, "lateral_source": None},
+            {"n": 0, "m": 2, "frozen": False, "lateral_source": "{0,1}"},
+        ],
+        "meta_controllers": [
+            {"layer": 1, "n_options": 1, "step_count": 42},
+        ],
+        "selection_history": [
+            {"mc_step": i, "option_id": [0, 1], "reward": round(random.uniform(0.0, 1.0), 3)}
+            for i in range(1, 11)
+        ],
+        "active_option_id": [0, 1],
+        "active_option_steps": 47,
+        "last_action": 2,
+        "last_reward": 0.95,
+        "is_training": False,
+        "training_column": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live state (optional)
+# ---------------------------------------------------------------------------
+
+@st.cache_resource
+def _get_tlm():
+    from src.options.task_lifecycle import TaskLifecycleManager
+    return TaskLifecycleManager()
+
+
+def _live_state_dict(tlm) -> dict:
+    s = tlm.get_state()
+    mc = tlm.meta_controllers.get(1)
+    history = mc.selection_history[-20:] if mc else []
+    active_id = s.active_option.option_id if s.active_option else None
+    active_steps = s.active_option.step_count if s.active_option else 0
+    training_col = (
+        f"{{{s.active_column.n},{s.active_column.m}}}"
+        if s.active_column else None
+    )
+    cols = [
+        {
+            "n": c.n, "m": c.m, "frozen": c.frozen,
+            "lateral_source": (
+                f"{{{c.lateral_source.n},{c.lateral_source.m}}}"
+                if c.lateral_source else None
+            ),
+        }
+        for c in tlm.columns.values()
+    ]
+    return {
+        "ae_error": s.ae_last_error,
+        "ae_threshold": tlm.ae.threshold,
+        "is_novel": s.ae_last_error > tlm.ae.threshold,
+        "gru_task_id": s.current_task_id,
+        "gru_confidence": s.gru_confidence,
+        "gru_all_probs": [],
+        "columns": cols,
+        "meta_controllers": [
+            {"layer": n, "n_options": mc.n_options, "step_count": mc._step_count}
+            for n, mc in tlm.meta_controllers.items()
+        ],
+        "selection_history": history,
+        "active_option_id": active_id,
+        "active_option_steps": active_steps,
+        "last_action": None,
+        "last_reward": None,
+        "is_training": s.is_training,
+        "training_column": training_col,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+def _render_ae(d: dict) -> None:
+    st.subheader("Autoencoder — Novelty Detection")
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Reconstruction Error", f"{d['ae_error']:.4f}")
+    col2.metric("Threshold", f"{d['ae_threshold']:.4f}")
+    novelty_label = "YES — Novel" if d["is_novel"] else "NO — Familiar"
+    novelty_color = "🔴" if d["is_novel"] else "🟢"
+    col3.metric("Is Novel?", f"{novelty_color} {novelty_label}")
+
+
+def _render_gru(d: dict) -> None:
+    st.subheader("GRU — Task Identification")
+    col1, col2 = st.columns(2)
+    task_label = str(d["gru_task_id"]) if d["gru_task_id"] != -1 else "−1 (uncertain)"
+    col1.metric("Predicted Task ID", task_label)
+    col2.metric("Confidence", f"{d['gru_confidence']:.2%}")
+    probs = d.get("gru_all_probs", [])
+    if probs:
+        import pandas as pd
+        df = pd.DataFrame(
+            {"Task": [f"Task {i}" for i in range(len(probs))], "P": probs}
+        ).set_index("Task")
+        st.bar_chart(df)
+
+
+def _render_columns(d: dict) -> None:
+    st.subheader("Progressive Network — Column Hierarchy")
+    cols = d.get("columns", [])
+    if not cols:
+        st.info("No columns created yet.")
+        return
+    for c in cols:
+        frozen_icon = "🔒 frozen" if c["frozen"] else "🟡 training"
+        lateral = f"  ← {c['lateral_source']}" if c["lateral_source"] else ""
+        st.markdown(f"- **`{{{c['n']},{c['m']}}}`** — {frozen_icon}{lateral}")
+    if d.get("is_training") and d.get("training_column"):
+        st.info(f"Training in progress: {d['training_column']}")
+
+
+def _render_meta_controllers(d: dict) -> None:
+    st.subheader("Meta-Controllers")
+    mcs = d.get("meta_controllers", [])
+    if not mcs:
+        st.info("No MetaControllers active.")
+        return
+    for mc in mcs:
+        st.markdown(
+            f"- **Layer n={mc['layer']}** — {mc['n_options']} option(s), "
+            f"{mc['step_count']} selections"
+        )
+
+
+def _render_option_history(d: dict) -> None:
+    st.subheader("Option Selection History (last 20)")
+    history = d.get("selection_history", [])
+    if not history:
+        st.info("No selections yet.")
+        return
+    import pandas as pd
+    rows = []
+    for h in history[-20:]:
+        oid = h.get("option_id")
+        oid_str = f"{{{oid[0]},{oid[1]}}}" if oid else "—"
+        rows.append({
+            "MC Step": h.get("mc_step", "—"),
+            "Option": oid_str,
+            "Reward": h.get("reward") if h.get("reward") is not None else "—",
+        })
+    st.dataframe(pd.DataFrame(rows), use_container_width=True)
+
+
+def _render_current(d: dict) -> None:
+    st.subheader("Current Step")
+    col1, col2, col3 = st.columns(3)
+    oid = d.get("active_option_id")
+    oid_str = f"{{{oid[0]},{oid[1]}}}" if oid else "None"
+    col1.metric("Active Option", oid_str)
+    col2.metric("Steps into Option", d.get("active_option_steps", 0))
+    action = d.get("last_action")
+    col3.metric("Last Action", str(action) if action is not None else "—")
+
+
+# ---------------------------------------------------------------------------
+# Main layout
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    st.title("ENS491 — Hierarchical Continual RL Agent")
+    st.caption(
+        "Architectural feasibility demonstration | Progress Report I | "
+        "Systematic experiments and ablations come after this integration milestone."
+    )
+
+    # Sidebar
+    with st.sidebar:
+        st.header("Settings")
+        live_mode = st.toggle("Live Mode", value=False)
+        if live_mode:
+            refresh_interval = st.slider("Refresh (s)", 1, 10, 2)
+        st.divider()
+        st.markdown("**Stack**")
+        st.markdown("- PyTorch 2.x + SB3\n- MiniGrid / Gymnasium\n- Progressive Networks")
+
+    # Load state
+    if live_mode:
+        try:
+            tlm = _get_tlm()
+            d = _live_state_dict(tlm)
+        except Exception as e:
+            st.error(f"Live mode error: {e}")
+            d = _load_demo_state()
+    else:
+        d = _load_demo_state()
+
+    # Render panels
+    _render_ae(d)
+    st.divider()
+    _render_gru(d)
+    st.divider()
+
+    left, right = st.columns([1, 1])
+    with left:
+        _render_columns(d)
+        _render_meta_controllers(d)
+    with right:
+        _render_option_history(d)
+        _render_current(d)
+
+    # Auto-refresh in live mode
+    if live_mode:
+        time.sleep(refresh_interval)
+        st.rerun()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/options/__init__.py
+++ b/src/options/__init__.py
@@ -1,0 +1,5 @@
+from src.options.option import Option
+from src.options.meta_controller import MetaController
+from src.options.task_lifecycle import TaskLifecycleManager
+
+__all__ = ["Option", "MetaController", "TaskLifecycleManager"]

--- a/src/options/meta_controller.py
+++ b/src/options/meta_controller.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import random
+from typing import Optional, TYPE_CHECKING
+
+from src.types import LayerIdx, MetaControllerOutput, Observation
+
+if TYPE_CHECKING:
+    from src.options.option import Option
+
+
+class MetaController:
+    """
+    Selects options for a given hierarchy layer.
+
+    Progress I: Epsilon-greedy selection with option history logging.
+    PPO-based optimisation is deferred to after the integration milestone —
+    the dynamic action space makes SB3 integration risky for Progress I.
+
+    Layer convention: n=1 is the root MetaController managing primitive
+    columns at n=0. Higher n = higher abstraction.
+    """
+
+    EPSILON_START = 1.0
+    EPSILON_END = 0.1
+    EPSILON_DECAY_STEPS = 500
+
+    def __init__(self, n: LayerIdx) -> None:
+        self.n = n
+        self.available_options: list[Option] = []
+        self._step_count: int = 0
+        self.selection_history: list[dict] = []  # for GUI and debugging
+
+    # ------------------------------------------------------------------
+    # Core interface
+    # ------------------------------------------------------------------
+
+    def select_option(self, obs: Observation) -> MetaControllerOutput:
+        if not self.available_options:
+            raise RuntimeError(
+                f"MetaController n={self.n} has no available options. "
+                "Call add_option() before select_option()."
+            )
+        self._step_count += 1
+        if random.random() < self._epsilon():
+            idx = random.randrange(len(self.available_options))
+        else:
+            # Placeholder for learned selection: currently picks the first option.
+            idx = 0
+        option = self.available_options[idx]
+        self.selection_history.append({
+            "mc_step": self._step_count,
+            "option_id": option.option_id,
+            "reward": None,
+        })
+        return MetaControllerOutput(selected_option_id=idx, option=option)
+
+    def add_option(self, option: Option) -> None:
+        """Add a stabilised option. Does not trigger retraining."""
+        self.available_options.append(option)
+
+    def step(self, obs: Observation, reward: float, done: bool) -> None:
+        """
+        Called after each env step with the env reward on this layer's channel.
+        Progress I: logs reward only.
+        Phase 2: triggers PPO update.
+        """
+        if self.selection_history and self.selection_history[-1]["reward"] is None:
+            self.selection_history[-1]["reward"] = reward
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _epsilon(self) -> float:
+        return max(
+            self.EPSILON_END,
+            self.EPSILON_START
+            - self._step_count * (self.EPSILON_START - self.EPSILON_END) / self.EPSILON_DECAY_STEPS,
+        )
+
+    @property
+    def n_options(self) -> int:
+        return len(self.available_options)
+
+    def __repr__(self) -> str:
+        return f"MetaController(n={self.n}, options={self.n_options}, steps={self._step_count})"

--- a/src/options/option.py
+++ b/src/options/option.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.types import Action, ColumnIdx, LayerIdx, Observation, OptionStepOutput
+
+if TYPE_CHECKING:
+    from src.continual_learning.column import Column
+
+
+class Option:
+    """
+    Sutton et al. (1999) option wrapping a frozen Column.
+
+    Termination strategy for Progress I: fixed step limit (MAX_STEPS).
+    Termination is checked at the end of each step — terminated=True signals
+    the MetaController to regain control.
+
+    option_id: (n, m) tuple matching the wrapped column's coordinates.
+    """
+
+    MAX_STEPS = 200
+
+    def __init__(self, column: Column, option_id: tuple[LayerIdx, ColumnIdx]) -> None:
+        self.column = column
+        self.option_id = option_id
+        self.step_count: int = 0
+
+    def step(self, obs: Observation) -> OptionStepOutput:
+        col_out = self.column.forward(obs)
+        self.step_count += 1
+        terminated = self.step_count >= self.MAX_STEPS
+        return OptionStepOutput(
+            action=col_out.action,
+            terminated=terminated,
+            info={"step_count": self.step_count, "value": col_out.value},
+        )
+
+    def reset(self) -> None:
+        self.step_count = 0
+
+    def can_initiate(self, obs: Observation) -> bool:
+        # Full state space initiation set (universal).
+        return True
+
+    def __repr__(self) -> str:
+        n, m = self.option_id
+        return f"Option({{{n},{m}}} steps={self.step_count}/{self.MAX_STEPS})"

--- a/src/options/task_lifecycle.py
+++ b/src/options/task_lifecycle.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import random
+from collections import deque
+from typing import Optional
+
+import numpy as np
+import torch
+
+from src.continual_learning.column import Column
+from src.options.meta_controller import MetaController
+from src.options.option import Option
+from src.task_detection.autoencoder import AutoencoderModule
+from src.task_detection.gru_identifier import GRUTaskIdentifier
+from src.types import (
+    Action, LayerIdx, ColumnIdx, Observation, SystemState, TaskID,
+)
+
+
+def _to_tensor(obs: Observation | np.ndarray | object) -> torch.Tensor:
+    if isinstance(obs, torch.Tensor):
+        return obs.float()
+    return torch.tensor(np.asarray(obs), dtype=torch.float32)
+
+
+class TaskLifecycleManager:
+    """
+    Orchestrates the full AE → GRU → MetaController → Option → Action pipeline.
+
+    Layer convention (fixed):
+        - Primitive columns live at n=0 with 1-indexed m.
+        - Root MetaController lives at n=1, managing all n=0 options.
+        - on_column_stabilized() adds options to meta_controllers[column.n + 1].
+
+    Phase 1 limitations (known):
+        - Single-level execution only; no recursive sub_layer traversal.
+        - _active_option is a single shared slot.
+          TODO (Phase 2): replace with _active_options: dict[LayerIdx, Option]
+          so each MetaController tracks its own active option independently,
+          which is required for correct recursive multi-level hierarchy.
+    """
+
+    NOVELTY_BUFFER_SIZE = 100
+
+    def __init__(self) -> None:
+        self.ae = AutoencoderModule()
+        self.gru = GRUTaskIdentifier()
+        self.columns: dict[tuple[LayerIdx, ColumnIdx], Column] = {}
+        self.meta_controllers: dict[LayerIdx, MetaController] = {}
+
+        self._current_task_id: TaskID = -1
+        self._active_option: Optional[Option] = None
+        self._training_column: Optional[Column] = None
+        self._n_tasks_seen: int = 0
+        self._recent_ae_errors: deque[float] = deque(maxlen=self.NOVELTY_BUFFER_SIZE)
+        self._last_ae_error: float = 0.0
+        self._last_gru_confidence: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Main step — called every environment step
+    # ------------------------------------------------------------------
+
+    def step(self, obs: Observation) -> Action:
+        obs_t = _to_tensor(obs)
+
+        # 1. AE novelty check
+        ae_out = self.ae.forward(obs_t)
+        self._last_ae_error = ae_out.reconstruction_error
+        self._recent_ae_errors.append(ae_out.reconstruction_error)
+
+        if ae_out.is_novel:
+            # Guardrail: do not open another column while one is training
+            if self._training_column is not None:
+                return random.randint(0, 6)
+            self.on_novel_task_detected()
+            return random.randint(0, 6)
+
+        # 2. GRU task identification
+        self.gru.observe(obs_t)
+        gru_out = self.gru.forward(self.gru.get_sequence())
+        self._current_task_id = gru_out.task_id
+        self._last_gru_confidence = gru_out.confidence
+
+        # 3. Route through root MetaController (n=1 manages n=0 primitives)
+        root_mc = self.meta_controllers.get(1)
+        if root_mc is None or not root_mc.available_options:
+            return random.randint(0, 6)
+
+        # 4. Single-level leaf execution (Phase 1)
+        #    Phase 2 NOTE: recursive non-leaf execution requires sub_layer support
+        #    and per-MetaController active option tracking — not implemented here.
+        if self._active_option is None:
+            mc_out = root_mc.select_option(obs_t)
+            self._active_option = mc_out.option
+            self._active_option.reset()
+
+        opt_out = self._active_option.step(obs_t)
+        if opt_out.terminated:
+            self._active_option = None
+
+        return opt_out.action
+
+    def on_reward(self, reward: float, done: bool) -> None:
+        """Feed env reward to the root MetaController on its separate channel."""
+        root_mc = self.meta_controllers.get(1)
+        if root_mc is not None and self._active_option is not None:
+            obs_placeholder = torch.zeros(147)  # MC reward channel; obs unused in Progress I
+            root_mc.step(obs_placeholder, reward, done)
+
+    # ------------------------------------------------------------------
+    # Lifecycle events
+    # ------------------------------------------------------------------
+
+    def on_novel_task_detected(self) -> None:
+        """Open a new primitive column. Caller is responsible for training it."""
+        m = self._n_tasks_seen + 1  # 1-indexed
+        n = 0
+        lateral = self.columns.get((n, m - 1)) if m > 1 else None
+        col = Column(n=n, m=m, lateral_source=lateral)
+        self.columns[(n, m)] = col
+        self._n_tasks_seen += 1
+        # Expand GRU head for the new task (0-indexed task id)
+        self.gru.register_new_task(self._n_tasks_seen - 1)
+        self._training_column = col
+
+    def on_column_stabilized(self, column: Column) -> None:
+        """
+        Freeze column, wrap as option, add to MetaController at layer n+1.
+        Only called after StabilizationMonitor.is_stable() returns True.
+        """
+        column.freeze()
+        option = column.as_option()
+        mc_layer: LayerIdx = column.n + 1
+        if mc_layer not in self.meta_controllers:
+            self.meta_controllers[mc_layer] = MetaController(mc_layer)
+        self.meta_controllers[mc_layer].add_option(option)
+        self._training_column = None
+
+    # ------------------------------------------------------------------
+    # State query
+    # ------------------------------------------------------------------
+
+    def get_state(self) -> SystemState:
+        total_options = sum(mc.n_options for mc in self.meta_controllers.values())
+        return SystemState(
+            current_task_id=self._current_task_id,
+            active_column=self._training_column,
+            active_option=self._active_option,
+            is_training=self._training_column is not None,
+            ae_last_error=self._last_ae_error,
+            gru_confidence=self._last_gru_confidence,
+            n_columns=len(self.columns),
+            n_options=total_options,
+        )

--- a/src/task_detection/__init__.py
+++ b/src/task_detection/__init__.py
@@ -1,0 +1,4 @@
+from src.task_detection.autoencoder import AutoencoderModule
+from src.task_detection.gru_identifier import GRUTaskIdentifier
+
+__all__ = ["AutoencoderModule", "GRUTaskIdentifier"]

--- a/src/task_detection/autoencoder.py
+++ b/src/task_detection/autoencoder.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import statistics
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from src.types import AEOutput, Observation
+
+
+def _to_tensor(obs: Observation | object) -> torch.Tensor:
+    if isinstance(obs, torch.Tensor):
+        return obs.float()
+    import numpy as np
+    return torch.tensor(obs, dtype=torch.float32)
+
+
+class AutoencoderModule(nn.Module):
+    """
+    MLP autoencoder for observation-level novelty detection.
+
+    Architecture: 147 → 64 → 32 (latent) → 64 → 147
+    Novelty: reconstruction_error (MSE) > threshold → is_novel = True
+
+    Calibration protocol for demo:
+        1. Collect familiar-task observations into a buffer.
+        2. Call train_on_batch() repeatedly on that buffer.
+        3. Call update_threshold() on the buffer's reconstruction errors.
+        4. Freeze threshold (do not call update_threshold() again during inference).
+           Novel observations inflate the threshold and weaken detection.
+    """
+
+    def __init__(
+        self,
+        obs_dim: int = 147,
+        latent_dim: int = 32,
+        threshold: float = 0.05,
+        lr: float = 1e-3,
+    ) -> None:
+        super().__init__()
+        self.obs_dim = obs_dim
+        self.latent_dim = latent_dim
+        self.threshold = threshold
+
+        self.encoder = nn.Sequential(
+            nn.Linear(obs_dim, 64),
+            nn.ReLU(),
+            nn.Linear(64, latent_dim),
+        )
+        self.decoder = nn.Sequential(
+            nn.Linear(latent_dim, 64),
+            nn.ReLU(),
+            nn.Linear(64, obs_dim),
+        )
+        self._optimizer = torch.optim.Adam(self.parameters(), lr=lr)
+
+    def encode(self, obs: Observation) -> torch.Tensor:
+        x = _to_tensor(obs)
+        if x.dim() == 1:
+            x = x.unsqueeze(0)
+        return self.encoder(x).squeeze(0)
+
+    def decode(self, z: torch.Tensor) -> torch.Tensor:
+        if z.dim() == 1:
+            z = z.unsqueeze(0)
+        return self.decoder(z).squeeze(0)
+
+    def forward(self, obs: Observation) -> AEOutput:
+        x = _to_tensor(obs)
+        if x.dim() == 1:
+            x = x.unsqueeze(0)
+        z = self.encoder(x)
+        recon = self.decoder(z)
+        error = F.mse_loss(recon, x).item()
+        return AEOutput(
+            reconstruction_error=error,
+            is_novel=error > self.threshold,
+            latent_z=z.squeeze(0).detach(),
+        )
+
+    def train_on_batch(self, obs_batch: torch.Tensor) -> float:
+        """One gradient step on a batch. Returns mean MSE loss."""
+        self.train()
+        self._optimizer.zero_grad()
+        z = self.encoder(obs_batch)
+        recon = self.decoder(z)
+        loss = F.mse_loss(recon, obs_batch)
+        loss.backward()
+        self._optimizer.step()
+        self.eval()
+        return loss.item()
+
+    def update_threshold(self, recent_errors: list[float]) -> None:
+        """
+        Adaptive threshold: mean + 2*std of familiar-task errors.
+        Only call this on familiar-task error distributions.
+        """
+        if len(recent_errors) < 2:
+            return
+        mean = statistics.mean(recent_errors)
+        std = statistics.stdev(recent_errors)
+        self.threshold = mean + 2.0 * std
+
+    def compute_errors(self, obs_batch: torch.Tensor) -> list[float]:
+        """Compute per-sample reconstruction errors for calibration."""
+        self.eval()
+        with torch.no_grad():
+            z = self.encoder(obs_batch)
+            recon = self.decoder(z)
+            errors = F.mse_loss(recon, obs_batch, reduction="none").mean(dim=1)
+        return errors.tolist()

--- a/src/task_detection/gru_identifier.py
+++ b/src/task_detection/gru_identifier.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from src.types import GRUOutput, Observation, ObsSequence, TaskID
+
+
+def _to_tensor(obs: Observation | object) -> torch.Tensor:
+    if isinstance(obs, torch.Tensor):
+        return obs.float()
+    import numpy as np
+    return torch.tensor(obs, dtype=torch.float32)
+
+
+class GRUTaskIdentifier(nn.Module):
+    """
+    GRU-based task classifier: "Which task is this sequence from?"
+
+    Input: last SEQ_LEN observations (zero-padded if buffer not full).
+    Output: GRUOutput with task_id (-1 if confidence < threshold), confidence,
+            and full probability vector.
+
+    register_new_task() expands the output head to cover the new task ID.
+    It is idempotent: no-op if the head already covers that task.
+
+    Training protocol for demo:
+        1. Collect labelled sequences offline (one pass per known task).
+        2. Call train_supervised(sequences, labels).
+        3. Validate task_id / confidence / all_probs / register_new_task() head expansion.
+    """
+
+    SEQ_LEN = 20
+    CONFIDENCE_THRESHOLD = 0.6
+
+    def __init__(
+        self,
+        obs_dim: int = 147,
+        hidden_size: int = 64,
+        num_tasks: int = 1,
+        lr: float = 1e-3,
+    ) -> None:
+        super().__init__()
+        self.obs_dim = obs_dim
+        self.hidden_size = hidden_size
+        self._num_tasks = num_tasks
+
+        self.gru = nn.GRU(input_size=obs_dim, hidden_size=hidden_size, batch_first=True)
+        self.head = nn.Linear(hidden_size, num_tasks)
+
+        self._obs_buffer: deque[torch.Tensor] = deque(maxlen=self.SEQ_LEN)
+        self._optimizer = torch.optim.Adam(self.parameters(), lr=lr)
+
+    # ------------------------------------------------------------------
+    # Rolling buffer helpers
+    # ------------------------------------------------------------------
+
+    def observe(self, obs: Observation) -> None:
+        """Append one observation to the rolling buffer."""
+        self._obs_buffer.append(_to_tensor(obs))
+
+    def get_sequence(self) -> ObsSequence:
+        """Return (SEQ_LEN, obs_dim) tensor, zero-padded at start if buffer not full."""
+        buf = list(self._obs_buffer)
+        pad_len = self.SEQ_LEN - len(buf)
+        tensors = [torch.zeros(self.obs_dim)] * pad_len + buf
+        return torch.stack(tensors)  # (SEQ_LEN, obs_dim)
+
+    # ------------------------------------------------------------------
+    # Core interface
+    # ------------------------------------------------------------------
+
+    def forward(self, obs_sequence: ObsSequence) -> GRUOutput:
+        """
+        obs_sequence: (N, obs_dim) — typically N = SEQ_LEN.
+        Returns GRUOutput. task_id = -1 when confidence < CONFIDENCE_THRESHOLD.
+        """
+        x = obs_sequence.unsqueeze(0)  # (1, N, obs_dim)
+        self.eval()
+        with torch.no_grad():
+            _, h_n = self.gru(x)          # h_n: (1, 1, hidden_size)
+            logits = self.head(h_n.squeeze())  # (num_tasks,)
+        probs = F.softmax(logits, dim=-1)
+        confidence = probs.max().item()
+        predicted = probs.argmax().item()
+        task_id: TaskID = predicted if confidence >= self.CONFIDENCE_THRESHOLD else -1
+        return GRUOutput(task_id=task_id, confidence=confidence, all_probs=probs.detach())
+
+    def register_new_task(self, task_id: TaskID) -> None:
+        """
+        Expand the output head to cover task_id.
+        Idempotent: does nothing if head already has task_id + 1 outputs.
+        """
+        needed = task_id + 1
+        if needed <= self._num_tasks:
+            return  # head already covers this task
+
+        old_head = self.head
+        new_head = nn.Linear(self.hidden_size, needed)
+        with torch.no_grad():
+            new_head.weight[:self._num_tasks] = old_head.weight
+            new_head.bias[:self._num_tasks] = old_head.bias
+            # New row: small random init
+            nn.init.xavier_uniform_(new_head.weight[self._num_tasks:])
+            nn.init.zeros_(new_head.bias[self._num_tasks:])
+        self.head = new_head
+        self._num_tasks = needed
+        # Rebuild optimiser to include new head parameters
+        self._optimizer = torch.optim.Adam(self.parameters(), lr=self._optimizer.defaults["lr"])
+
+    def train_supervised(
+        self,
+        sequences: torch.Tensor,  # (B, SEQ_LEN, obs_dim)
+        labels: torch.Tensor,     # (B,) int64
+        epochs: int = 10,
+    ) -> float:
+        """Supervised cross-entropy training. Returns final epoch loss."""
+        self.train()
+        final_loss = 0.0
+        for _ in range(epochs):
+            self._optimizer.zero_grad()
+            _, h_n = self.gru(sequences)          # h_n: (1, B, hidden_size)
+            logits = self.head(h_n.squeeze(0))    # (B, num_tasks)
+            loss = F.cross_entropy(logits, labels)
+            loss.backward()
+            self._optimizer.step()
+            final_loss = loss.item()
+        self.eval()
+        return final_loss
+
+    @property
+    def num_tasks(self) -> int:
+        return self._num_tasks

--- a/src/types.py
+++ b/src/types.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+
+# MiniGrid with FlatObsWrapper: 7×7×3 = 147-dim float vector
+Observation = torch.Tensor   # shape (147,)
+ObsSequence = torch.Tensor   # shape (N, 147)
+Action = int                 # discrete 0-6 (MiniGrid)
+TaskID = int                 # 0-indexed; -1 = unknown/uncertain
+LayerIdx = int               # n: 0 = primitive, 1 = first meta layer, …
+ColumnIdx = int              # m: 1-indexed within a layer
+
+
+@dataclass
+class AEOutput:
+    reconstruction_error: float
+    is_novel: bool
+    latent_z: torch.Tensor
+
+
+@dataclass
+class GRUOutput:
+    task_id: TaskID
+    confidence: float
+    all_probs: torch.Tensor
+
+
+@dataclass
+class ColumnOutput:
+    action: Action
+    value: float
+    activations: dict  # int → torch.Tensor (layer index → hidden activation)
+
+
+@dataclass
+class OptionStepOutput:
+    action: Action
+    terminated: bool
+    info: dict
+
+
+@dataclass
+class MetaControllerOutput:
+    selected_option_id: int
+    option: object  # Option — forward reference avoids circular import
+
+
+@dataclass
+class SystemState:
+    current_task_id: TaskID
+    active_column: Optional[object]   # Column | None
+    active_option: Optional[object]   # Option | None
+    is_training: bool
+    ae_last_error: float = 0.0
+    gru_confidence: float = 0.0
+    n_columns: int = 0
+    n_options: int = 0

--- a/tests/test_autoencoder.py
+++ b/tests/test_autoencoder.py
@@ -1,0 +1,72 @@
+"""Autoencoder unit tests (AE-1 / AE-2)."""
+
+import torch
+
+from src.task_detection.autoencoder import AutoencoderModule
+from src.types import AEOutput
+
+
+def test_forward_returns_ae_output():
+    ae = AutoencoderModule()
+    obs = torch.randn(147)
+    out = ae.forward(obs)
+    assert isinstance(out, AEOutput)
+    assert isinstance(out.reconstruction_error, float)
+    assert isinstance(out.is_novel, bool)
+    assert out.latent_z.shape == (32,)
+
+
+def test_novelty_flag_respects_threshold():
+    ae = AutoencoderModule(threshold=1e6)   # enormous threshold → never novel
+    obs = torch.randn(147)
+    out = ae.forward(obs)
+    assert out.is_novel is False
+
+    ae2 = AutoencoderModule(threshold=0.0)  # zero threshold → always novel
+    out2 = ae2.forward(obs)
+    assert out2.is_novel is True
+
+
+def test_train_on_batch_reduces_loss():
+    ae = AutoencoderModule()
+    obs_batch = torch.randn(16, 147)
+    loss_before = ae.train_on_batch(obs_batch)
+    # Train for many steps
+    for _ in range(50):
+        ae.train_on_batch(obs_batch)
+    loss_after = ae.train_on_batch(obs_batch)
+    assert loss_after < loss_before, "Loss did not decrease after training"
+
+
+def test_update_threshold_changes_value():
+    ae = AutoencoderModule(threshold=0.05)
+    original = ae.threshold
+    # Use a list of low errors — threshold should be set to mean + 2*std
+    errors = [0.01, 0.012, 0.011, 0.013, 0.010]
+    ae.update_threshold(errors)
+    assert ae.threshold != original
+    assert ae.threshold > 0
+
+
+def test_update_threshold_noop_on_single_error():
+    """update_threshold requires at least 2 values (std is undefined for 1)."""
+    ae = AutoencoderModule(threshold=0.05)
+    ae.update_threshold([0.01])
+    assert ae.threshold == 0.05  # unchanged
+
+
+def test_compute_errors_returns_per_sample_list():
+    ae = AutoencoderModule()
+    obs_batch = torch.randn(8, 147)
+    errors = ae.compute_errors(obs_batch)
+    assert len(errors) == 8
+    assert all(isinstance(e, float) for e in errors)
+
+
+def test_encode_decode_shape():
+    ae = AutoencoderModule()
+    obs = torch.randn(147)
+    z = ae.encode(obs)
+    assert z.shape == (32,)
+    recon = ae.decode(z)
+    assert recon.shape == (147,)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,0 +1,120 @@
+"""
+Column unit tests (PN-3 / PN-4 scope).
+Uses a MockPolicy so tests run without SB3 or gym.
+"""
+
+import pytest
+import torch
+
+from src.continual_learning.column import Column
+from src.types import ColumnOutput
+
+
+class MockMlpExtractor:
+    def __init__(self):
+        self._acts = {0: torch.randn(64), 1: torch.randn(64)}
+
+    def get_activations(self):
+        return self._acts
+
+    def __call__(self, x):
+        return self._acts[1], self._acts[1]
+
+
+class MockPolicy:
+    """Minimal policy stub implementing the Column interface contract."""
+
+    def __init__(self):
+        self.mlp_extractor = MockMlpExtractor()
+        self._params = [torch.nn.Parameter(torch.randn(3, 3))]
+
+    def predict(self, obs, deterministic=True):
+        return 3, None  # always action 3
+
+    def predict_values(self, obs):
+        return torch.tensor([[0.5]])
+
+    def parameters(self):
+        return iter(self._params)
+
+    def named_parameters(self):
+        return iter([("w", self._params[0])])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_column_forward_raises_without_policy():
+    col = Column(n=0, m=1)
+    with pytest.raises(RuntimeError, match="policy is None"):
+        col.forward(torch.randn(147))
+
+
+def test_column_forward_returns_column_output():
+    col = Column(n=0, m=1)
+    col.policy = MockPolicy()
+    out = col.forward(torch.randn(147))
+    assert isinstance(out, ColumnOutput)
+    assert isinstance(out.action, int)
+    assert 0 <= out.action <= 6
+    assert isinstance(out.value, float)
+    assert isinstance(out.activations, dict)
+
+
+def test_column_freeze_sets_flag():
+    col = Column(n=0, m=1)
+    col.policy = MockPolicy()
+    assert col.frozen is False
+    col.freeze()
+    assert col.frozen is True
+
+
+def test_column_freeze_disables_grad():
+    col = Column(n=0, m=1)
+    col.policy = MockPolicy()
+    # Ensure param starts requiring grad
+    for p in col.policy.parameters():
+        p.requires_grad_(True)
+    col.freeze()
+    for p in col.policy.parameters():
+        assert not p.requires_grad
+
+
+def test_column_get_activations_nonempty():
+    col = Column(n=0, m=1)
+    col.policy = MockPolicy()
+    col.forward(torch.randn(147))
+    acts = col.get_activations()
+    assert len(acts) > 0
+
+
+def test_column_freeze_raises_without_policy():
+    col = Column(n=0, m=1)
+    with pytest.raises(RuntimeError, match="policy is None"):
+        col.freeze()
+
+
+def test_column_sub_layer_field_exists():
+    """sub_layer must exist on every Column — Phase 2 recursive hook."""
+    col = Column(n=0, m=1)
+    assert hasattr(col, "sub_layer")
+    assert col.sub_layer is None
+
+
+def test_column_1indexed_m():
+    """First column is {0,1}, second is {0,2}."""
+    col1 = Column(n=0, m=1)
+    col2 = Column(n=0, m=2, lateral_source=col1)
+    assert col1.m == 1
+    assert col2.m == 2
+    assert col2.lateral_source is col1
+
+
+def test_column_as_option():
+    from src.options.option import Option
+    col = Column(n=0, m=1)
+    col.policy = MockPolicy()
+    opt = col.as_option()
+    assert isinstance(opt, Option)
+    assert opt.option_id == (0, 1)

--- a/tests/test_gru.py
+++ b/tests/test_gru.py
@@ -1,0 +1,82 @@
+"""GRU Task Identifier unit tests (GRU-1 / GRU-2)."""
+
+import torch
+
+from src.task_detection.gru_identifier import GRUTaskIdentifier
+from src.types import GRUOutput
+
+
+def test_forward_returns_gru_output():
+    gru = GRUTaskIdentifier(num_tasks=2)
+    seq = torch.randn(20, 147)
+    out = gru.forward(seq)
+    assert isinstance(out, GRUOutput)
+    assert out.all_probs.shape == (2,)
+    assert abs(out.all_probs.sum().item() - 1.0) < 1e-5
+
+
+def test_task_id_uncertain_when_confidence_low():
+    """With random weights and 1-task head, confidence may be below threshold."""
+    gru = GRUTaskIdentifier(num_tasks=10)  # many tasks → low confidence
+    seq = torch.randn(20, 147)
+    out = gru.forward(seq)
+    # task_id is -1 if confidence < 0.6
+    if out.confidence < gru.CONFIDENCE_THRESHOLD:
+        assert out.task_id == -1
+    else:
+        assert 0 <= out.task_id < 10
+
+
+def test_register_new_task_expands_head():
+    gru = GRUTaskIdentifier(num_tasks=1)
+    assert gru.num_tasks == 1
+    gru.register_new_task(task_id=1)  # need output dim 2
+    assert gru.num_tasks == 2
+    # Verify forward still works
+    seq = torch.randn(20, 147)
+    out = gru.forward(seq)
+    assert out.all_probs.shape == (2,)
+
+
+def test_register_new_task_idempotent():
+    """register_new_task is a no-op if head already covers the task."""
+    gru = GRUTaskIdentifier(num_tasks=3)
+    gru.register_new_task(task_id=2)  # task_id+1 = 3, already covered
+    assert gru.num_tasks == 3  # unchanged
+
+
+def test_register_new_task_preserves_existing_weights():
+    """Old head weights must be preserved when expanding."""
+    gru = GRUTaskIdentifier(num_tasks=2)
+    old_weight = gru.head.weight.detach().clone()
+    gru.register_new_task(task_id=2)  # expand to 3
+    assert gru.num_tasks == 3
+    assert torch.allclose(gru.head.weight[:2], old_weight)
+
+
+def test_observe_and_get_sequence():
+    gru = GRUTaskIdentifier()
+    for _ in range(25):
+        gru.observe(torch.randn(147))
+    seq = gru.get_sequence()
+    assert seq.shape == (20, 147)
+
+
+def test_get_sequence_zero_pads_short_buffer():
+    gru = GRUTaskIdentifier()
+    # Only 5 observations in buffer
+    for _ in range(5):
+        gru.observe(torch.randn(147))
+    seq = gru.get_sequence()
+    assert seq.shape == (20, 147)
+    # First 15 rows should be all zeros
+    assert torch.all(seq[:15] == 0)
+
+
+def test_train_supervised_reduces_loss():
+    gru = GRUTaskIdentifier(num_tasks=2)
+    sequences = torch.randn(20, 20, 147)
+    labels = torch.randint(0, 2, (20,))
+    loss_before = gru.train_supervised(sequences, labels, epochs=1)
+    loss_after = gru.train_supervised(sequences, labels, epochs=20)
+    assert loss_after <= loss_before + 0.5, "Supervised loss did not converge"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,152 @@
+"""
+INT-2: TaskLifecycleManager end-to-end smoke tests.
+
+Tests the full AE → GRU → MetaController → Option → Action pipeline
+without any live training.
+"""
+
+import torch
+import pytest
+
+from src.continual_learning.column import Column
+from src.options.task_lifecycle import TaskLifecycleManager
+from src.types import SystemState
+
+
+class _MockPolicy:
+    def __init__(self):
+        class _Ext:
+            def get_activations(self):
+                return {0: torch.randn(64), 1: torch.randn(64)}
+        self.mlp_extractor = _Ext()
+
+    def predict(self, obs, deterministic=True):
+        return 4, None
+
+    def predict_values(self, obs):
+        return torch.tensor([[0.6]])
+
+    def parameters(self):
+        return iter([])
+
+    def named_parameters(self):
+        return iter([])
+
+
+def _make_trained_column(n: int, m: int, lateral=None) -> Column:
+    col = Column(n=n, m=m, lateral_source=lateral)
+    col.policy = _MockPolicy()
+    return col
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_step_returns_valid_action_without_any_columns():
+    """Random action (0-6) when no columns/MC exist."""
+    tlm = TaskLifecycleManager()
+    # Force AE to not trigger novelty
+    tlm.ae.threshold = 1e6
+    obs = torch.randn(147)
+    action = tlm.step(obs)
+    assert isinstance(action, int)
+    assert 0 <= action <= 6
+
+
+def test_step_100_times_no_crash():
+    """100 steps must all return int 0-6 with no exception."""
+    tlm = TaskLifecycleManager()
+    tlm.ae.threshold = 1e6  # suppress novelty
+
+    # Manually install one stabilised column so MC has an option
+    col = _make_trained_column(0, 1)
+    tlm.columns[(0, 1)] = col
+    tlm._n_tasks_seen = 1
+    tlm.on_column_stabilized(col)
+
+    obs = torch.randn(147)
+    for _ in range(100):
+        action = tlm.step(obs)
+        assert isinstance(action, int)
+        assert 0 <= action <= 6, f"Action {action} out of MiniGrid range"
+
+
+def test_on_novel_task_detected_opens_column():
+    tlm = TaskLifecycleManager()
+    assert len(tlm.columns) == 0
+    tlm.on_novel_task_detected()
+    assert len(tlm.columns) == 1
+    # First column is {0, 1}
+    assert (0, 1) in tlm.columns
+
+
+def test_on_novel_task_detected_increments_gru_head():
+    tlm = TaskLifecycleManager()
+    before = tlm.gru.num_tasks
+    tlm.on_novel_task_detected()
+    # register_new_task(0) expands to at least 1
+    assert tlm.gru.num_tasks >= before
+
+
+def test_on_column_stabilized_adds_option_to_mc_n1():
+    tlm = TaskLifecycleManager()
+    col = _make_trained_column(0, 1)
+    tlm.on_column_stabilized(col)
+    assert 1 in tlm.meta_controllers
+    assert tlm.meta_controllers[1].n_options == 1
+
+
+def test_on_column_stabilized_freezes_column():
+    tlm = TaskLifecycleManager()
+    col = _make_trained_column(0, 1)
+    tlm.on_column_stabilized(col)
+    assert col.frozen is True
+
+
+def test_second_column_gets_lateral_source():
+    tlm = TaskLifecycleManager()
+    tlm.on_novel_task_detected()
+    tlm.on_novel_task_detected()
+    assert (0, 2) in tlm.columns
+    col2 = tlm.columns[(0, 2)]
+    assert col2.lateral_source is tlm.columns[(0, 1)]
+
+
+def test_no_double_novel_task_while_training():
+    """If _training_column is not None, step() must not call on_novel_task_detected again."""
+    tlm = TaskLifecycleManager()
+    # Make AE always report novelty
+    tlm.ae.threshold = 0.0
+
+    tlm.step(torch.randn(147))   # first novel: opens {0,1}, sets _training_column
+    assert tlm._training_column is not None
+    n_cols_before = len(tlm.columns)
+
+    tlm.step(torch.randn(147))   # second novel: must NOT open another column
+    assert len(tlm.columns) == n_cols_before
+
+
+def test_get_state_returns_system_state():
+    tlm = TaskLifecycleManager()
+    state = tlm.get_state()
+    assert isinstance(state, SystemState)
+    assert state.n_columns == len(tlm.columns)
+
+
+def test_layer_indexing_mc_at_n_plus_1():
+    """Primitive column at n=0 → its option goes to MC at n=1."""
+    tlm = TaskLifecycleManager()
+    col = _make_trained_column(n=0, m=1)
+    tlm.on_column_stabilized(col)
+    assert 1 in tlm.meta_controllers
+    assert 0 not in tlm.meta_controllers, "MC must be at n+1=1, not n=0"
+
+
+def test_column_m_is_1indexed():
+    """First two novel tasks open columns {0,1} and {0,2}."""
+    tlm = TaskLifecycleManager()
+    tlm.on_novel_task_detected()
+    tlm.on_novel_task_detected()
+    ms = [m for (_, m) in tlm.columns]
+    assert sorted(ms) == [1, 2]

--- a/tests/test_meta_controller.py
+++ b/tests/test_meta_controller.py
@@ -1,0 +1,92 @@
+"""MetaController unit tests (OPT-1)."""
+
+import pytest
+import torch
+
+from src.continual_learning.column import Column
+from src.options.meta_controller import MetaController
+from src.options.option import Option
+from src.types import MetaControllerOutput
+
+
+class MockPolicy:
+    def __init__(self):
+        class _Ext:
+            def get_activations(self):
+                return {0: torch.randn(64), 1: torch.randn(64)}
+        self.mlp_extractor = _Ext()
+
+    def predict(self, obs, deterministic=True):
+        return 0, None
+
+    def predict_values(self, obs):
+        return torch.tensor([[0.5]])
+
+    def parameters(self):
+        return iter([])
+
+    def named_parameters(self):
+        return iter([])
+
+
+def _make_option(n: int, m: int) -> Option:
+    col = Column(n=n, m=m)
+    col.policy = MockPolicy()
+    col.freeze()
+    return Option(column=col, option_id=(n, m))
+
+
+def test_select_option_raises_without_options():
+    mc = MetaController(n=1)
+    with pytest.raises(RuntimeError, match="no available options"):
+        mc.select_option(torch.randn(147))
+
+
+def test_add_option_increases_count():
+    mc = MetaController(n=1)
+    assert mc.n_options == 0
+    mc.add_option(_make_option(0, 1))
+    assert mc.n_options == 1
+    mc.add_option(_make_option(0, 2))
+    assert mc.n_options == 2
+
+
+def test_select_option_returns_valid_output():
+    mc = MetaController(n=1)
+    opt = _make_option(0, 1)
+    mc.add_option(opt)
+    out = mc.select_option(torch.randn(147))
+    assert isinstance(out, MetaControllerOutput)
+    assert out.option is opt
+    assert out.selected_option_id == 0
+
+
+def test_select_option_id_in_valid_range():
+    mc = MetaController(n=1)
+    for i in range(1, 4):
+        mc.add_option(_make_option(0, i))
+    obs = torch.randn(147)
+    for _ in range(50):
+        out = mc.select_option(obs)
+        assert 0 <= out.selected_option_id < 3
+
+
+def test_selection_history_logged():
+    mc = MetaController(n=1)
+    mc.add_option(_make_option(0, 1))
+    mc.select_option(torch.randn(147))
+    assert len(mc.selection_history) == 1
+    assert "option_id" in mc.selection_history[0]
+
+
+def test_step_logs_reward():
+    mc = MetaController(n=1)
+    mc.add_option(_make_option(0, 1))
+    mc.select_option(torch.randn(147))
+    mc.step(torch.randn(147), reward=0.9, done=False)
+    assert mc.selection_history[-1]["reward"] == 0.9
+
+
+def test_layer_index_stored():
+    mc = MetaController(n=1)
+    assert mc.n == 1

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,0 +1,86 @@
+"""Option wrapper unit tests (OPT-2)."""
+
+import torch
+
+from src.continual_learning.column import Column
+from src.options.option import Option
+from src.types import OptionStepOutput
+
+
+class MockPolicy:
+    def __init__(self):
+        class _Ext:
+            def get_activations(self):
+                return {0: torch.randn(64), 1: torch.randn(64)}
+
+        self.mlp_extractor = _Ext()
+
+    def predict(self, obs, deterministic=True):
+        return 2, None
+
+    def predict_values(self, obs):
+        return torch.tensor([[0.7]])
+
+    def parameters(self):
+        return iter([])
+
+    def named_parameters(self):
+        return iter([])
+
+
+def _make_option() -> Option:
+    col = Column(n=0, m=1)
+    col.policy = MockPolicy()
+    col.freeze()
+    return Option(column=col, option_id=(0, 1))
+
+
+def test_option_step_returns_option_step_output():
+    opt = _make_option()
+    out = opt.step(torch.randn(147))
+    assert isinstance(out, OptionStepOutput)
+    assert isinstance(out.action, int)
+    assert isinstance(out.terminated, bool)
+    assert "step_count" in out.info
+
+
+def test_option_action_in_valid_range():
+    opt = _make_option()
+    for _ in range(10):
+        out = opt.step(torch.randn(147))
+        assert 0 <= out.action <= 6
+
+
+def test_option_terminates_at_max_steps():
+    opt = _make_option()
+    opt.reset()
+    out = None
+    for _ in range(Option.MAX_STEPS):
+        out = opt.step(torch.randn(147))
+    assert out.terminated is True
+    assert opt.step_count == Option.MAX_STEPS
+
+
+def test_option_not_terminated_before_max_steps():
+    opt = _make_option()
+    for _ in range(Option.MAX_STEPS - 1):
+        out = opt.step(torch.randn(147))
+    assert out.terminated is False
+
+
+def test_option_reset_clears_step_count():
+    opt = _make_option()
+    for _ in range(50):
+        opt.step(torch.randn(147))
+    opt.reset()
+    assert opt.step_count == 0
+
+
+def test_option_can_initiate_always_true():
+    opt = _make_option()
+    assert opt.can_initiate(torch.randn(147)) is True
+
+
+def test_option_id_matches_column_coordinates():
+    opt = _make_option()
+    assert opt.option_id == (0, 1)

--- a/tests/test_pn_basic.py
+++ b/tests/test_pn_basic.py
@@ -1,0 +1,161 @@
+"""
+PN-1: Progressive Network mechanics test using synthetic data.
+
+Validates WITHOUT any RL training loop:
+  1. FlatObsWrapper produces (147,) observations.
+  2. Two-column forward pass works end-to-end.
+  3. Column {0,1} can be frozen.
+  4. Frozen Column {0,1} still produces activations after freeze().
+  5. Frozen Column {0,1} receives no gradients.
+  6. Column {0,2} reads Column {0,1} activations through lateral connections.
+  7. Lateral projection layers in Column {0,2} receive gradients.
+"""
+
+import pytest
+
+try:
+    import stable_baselines3  # noqa: F401 — presence check only
+except Exception as e:
+    pytest.skip(
+        f"stable_baselines3 not importable ({e}). "
+        "Fix: pip uninstall tensorflow -y (TF conflicts with torch.utils.tensorboard in this env).",
+        allow_module_level=True,
+    )
+
+import gymnasium as gym
+import minigrid  # noqa: F401
+import torch
+import torch.nn.functional as F
+from gymnasium.wrappers import FlattenObservation
+from minigrid.wrappers import ImgObsWrapper
+
+from src.continual_learning.column import Column
+from src.continual_learning.column_policy import ColumnPolicy, LateralMlpExtractor
+
+
+def _make_env():
+    """ImgObsWrapper (7×7×3) + FlattenObservation → (147,) uint8 obs."""
+    return FlattenObservation(ImgObsWrapper(gym.make("MiniGrid-Empty-8x8-v0")))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_column_with_policy(
+    n: int, m: int, lateral_source: Column | None = None
+) -> Column:
+    """Build a Column with an initialised ColumnPolicy (no training needed)."""
+    col = Column(n=n, m=m, lateral_source=lateral_source)
+    env = _make_env()
+    from stable_baselines3 import PPO
+    model = PPO(
+        ColumnPolicy,
+        env,
+        policy_kwargs={"lateral_source_column": lateral_source},
+        verbose=0,
+    )
+    col.policy = model.policy
+    env.close()
+    return col
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_flat_obs_shape():
+    """ImgObsWrapper + FlattenObservation produces (147,) observations (7×7×3)."""
+    env = _make_env()
+    obs, _ = env.reset()
+    env.close()
+    assert obs.shape == (147,), f"Expected (147,) got {obs.shape}"
+
+
+def test_two_column_forward_pass():
+    """Both columns forward without error; outputs have the right structure."""
+    col1 = _make_column_with_policy(n=0, m=1)
+    col2 = _make_column_with_policy(n=0, m=2, lateral_source=col1)
+
+    obs = torch.randn(147)
+    out1 = col1.forward(obs)
+    out2 = col2.forward(obs)
+
+    assert isinstance(out1.action, int)
+    assert 0 <= out1.action <= 6
+    assert isinstance(out2.action, int)
+    assert 0 <= out2.action <= 6
+
+
+def test_freeze_sets_flag_and_blocks_grad():
+    """After freeze(): frozen=True, all policy params have requires_grad=False."""
+    col1 = _make_column_with_policy(n=0, m=1)
+    col1.freeze()
+
+    assert col1.frozen is True
+    for p in col1.policy.parameters():
+        assert not p.requires_grad, "Frozen column parameter still has requires_grad=True"
+
+
+def test_frozen_column_still_produces_activations():
+    """Freeze does not prevent forward pass or activation storage."""
+    col1 = _make_column_with_policy(n=0, m=1)
+    col1.freeze()
+
+    obs = torch.randn(147)
+    out = col1.forward(obs)
+
+    acts = col1.get_activations()
+    assert len(acts) > 0, "No activations after frozen forward pass"
+    assert all(isinstance(v, torch.Tensor) for v in acts.values())
+
+
+def test_lateral_connections_read_source_activations():
+    """Column {0,2}'s extractor reads Column {0,1}'s activations through lateral connections."""
+    col1 = _make_column_with_policy(n=0, m=1)
+    col1.freeze()
+
+    col2 = _make_column_with_policy(n=0, m=2, lateral_source=col1)
+
+    # Verify lateral projection layers exist in col2's extractor
+    extractor = col2.policy.mlp_extractor
+    assert isinstance(extractor, LateralMlpExtractor)
+    assert hasattr(extractor, "lat1"), "lateral layer lat1 missing from col2 extractor"
+    assert hasattr(extractor, "lat2"), "lateral layer lat2 missing from col2 extractor"
+
+    # Forward col2 — internally re-runs col1 to get its activations
+    obs = torch.randn(147)
+    _ = col2.forward(obs)
+
+    acts2 = col2.get_activations()
+    assert len(acts2) > 0, "col2 produced no activations"
+
+
+def test_lateral_layers_receive_gradients_frozen_source_does_not():
+    """
+    On a synthetic loss over col2's output:
+      - col2's lateral projection weights receive gradients.
+      - col1's weights receive no gradients (frozen).
+    """
+    col1 = _make_column_with_policy(n=0, m=1)
+    col1.freeze()
+    col2 = _make_column_with_policy(n=0, m=2, lateral_source=col1)
+
+    obs_batch = torch.randn(4, 147)
+    extractor2 = col2.policy.mlp_extractor
+
+    # Run extractor forward (same path as during PPO update)
+    pi_feats, _ = extractor2(obs_batch)
+
+    # Dummy target: supervised loss to drive gradients
+    target = torch.zeros_like(pi_feats)
+    loss = F.mse_loss(pi_feats, target)
+    loss.backward()
+
+    # Lateral layers in col2 should have gradients
+    assert extractor2.lat1.weight.grad is not None, "lat1.weight has no grad"
+    assert extractor2.lat2.weight.grad is not None, "lat2.weight has no grad"
+
+    # col1's params must have no gradients
+    for name, p in col1.policy.named_parameters():
+        assert p.grad is None, f"Frozen col1 param '{name}' has grad — gradient leaked"


### PR DESCRIPTION
 ## Summary

  - Implement all four `src/` modules from scratch: Progressive Networks,
    Autoencoder, GRU Task Identifier, Options/MetaController, and
    TaskLifecycleManager integration
  - Add minimal Streamlit GUI with demo mode and live mode
  - Add complete unit and integration test suite (56 tests, all passing)
  - Add project documentation: CLAUDE.md, architecture specs, module interface
    contracts, project state/roadmap

  ## What's implemented

  **Continual Learning (`src/continual_learning/`)**
  - `Column` — Progressive Network column with `{n,m}` notation, `freeze()`,
    `as_option()`, `sub_layer` hook for Phase 2 recursive hierarchy
  - `LateralMlpExtractor` + `ColumnPolicy` — SB3 `ActorCriticPolicy` subclass
    with lateral connections (additive, `nn.Linear(64,64)`, no concatenation)
  - `ColumnTrainer` — SB3 PPO training loop with `StabilizationMonitor` callback
  - `StabilizationMonitor` — stabilization criterion: last 50 eps, mean > 0.85
    AND std < 0.05

  **Task Detection (`src/task_detection/`)**
  - `AutoencoderModule` — MLP 147→64→32→64→147, adaptive threshold (mean + 2σ)
  - `GRUTaskIdentifier` — hidden=64, N=20, supervised training, dynamic head
    expansion via `register_new_task()`

  **Options & Orchestration (`src/options/`)**
  - `Option` — Sutton et al. (1999) wrapper, fixed step limit (MAX_STEPS=200)
  - `MetaController` — epsilon-greedy selection for Progress I; PPO deferred to
    Phase 2 (dynamic action space makes SB3 integration non-trivial at this stage)
  - `TaskLifecycleManager` — full AE→GRU→MC→Option→action pipeline; re-entry
    guard prevents double column opening while training; reward channels kept separate

  **GUI (`src/gui/app.py`)**
  - Demo mode: loads `runs/demo_state.pkl` (falls back to hardcoded default)
  - Live mode: polls `TaskLifecycleManager.get_state()` with auto-rerun
  - Panels: AE novelty, GRU task ID + probability bars, column hierarchy,
    option selection history (last 20), current step info

  **Known Phase 1 limitation (documented in code)**
  - `TaskLifecycleManager` uses a single `_active_option` slot; recursive
    multi-level hierarchy requires per-MC option tracking — noted as
    `TODO (Phase 2)`

  ## Test plan

  - [x] `python -m pytest tests/ -v` — 56 passed, 0 failed
  - [x] PN mechanics: freeze blocks grad, lateral connections read source
        activations, lateral layers receive grad, frozen source does not
  - [x] AE: novelty flag respects threshold, loss decreases after training
  - [x] GRU: head expansion preserves old weights, zero-padding correct
  - [x] Integration: 100-step smoke test, column stabilization → MC wiring,
        re-entry guard for double novel detection
  - [ ] `streamlit run src/gui/app.py` — visual check in demo mode